### PR TITLE
Release dev: geo/contacts, object actions, form layout fixes, and pre-alpha README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.2+-00ADD8?logo=go&logoColor=white)](https://go.dev/dl/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Pre-Alpha](https://img.shields.io/badge/Status-Pre--Alpha-critical?style=for-the-badge)](https://github.com/ProjectMeru/sumeru)
+
+> [!CAUTION]
+> ### 🚧 Pre-Alpha Software
+>
+> Sumeru is **pre-alpha software**. It is under active development and is **not ready for production or commercial use**.
+>
+> - **No production use.** Do not deploy to production or run live business workloads. Stability, security, and data integrity are not guaranteed.
+> - **Not for sale.** Do not offer, resell, license, or deploy Sumeru to customers. This is not a commercial product.
+> - **Evaluation only.** Use for local development, testing, and feedback at your own risk.
+>
+> APIs, data models, and behavior may change without notice. There is no migration guarantee and no production support.
 
 **Sumeru** is an experimental ERP-style web application written in **Go**. It provides a PostgreSQL-backed ORM, installable **addons** (module XML under `<sumeru>` + manifests), model sync on startup, and a web UI (XML views, plain CSS, shell with sidebar and activity panel).
 
@@ -29,19 +41,19 @@ sumeru_custom_addons  ──replace + make generate──►  sumeru (core)
                 └── also loads  sumeru_addons (standard business apps)
 ```
 
-| Repository | Role | Remote |
-| ---------- | ---- | ------ |
-| **`sumeru`** | Core engine + kernel addons (`base`, `mail`, `sumeru_ai`, …). Pull-only for most teams. | `git@github.com:ProjectMeru/sumeru.git` |
-| **`sumeru_addons`** | Standard business apps (CRM, Sales, Inventory, …). Pull-only. | `git@github.com:ProjectMeru/sumeru_addons.git` |
-| **`sumeru_custom_addons`** | Your workspace: custom addons, local INI, generated imports, and the process you run. | `git@github.com:ProjectMeru/sumeru_custom_addons.git` |
+| Repository                 | Role                                                                                    | Remote                                                |
+| -------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **`sumeru`**               | Core engine + kernel addons (`base`, `mail`, `sumeru_ai`, …). Pull-only for most teams. | `git@github.com:ProjectMeru/sumeru.git`               |
+| **`sumeru_addons`**        | Standard business apps (CRM, Sales, Inventory, …). Pull-only.                           | `git@github.com:ProjectMeru/sumeru_addons.git`        |
+| **`sumeru_custom_addons`** | Your workspace: custom addons, local INI, generated imports, and the process you run.   | `git@github.com:ProjectMeru/sumeru_custom_addons.git` |
 
 **Entry binary (this repo):** `cmd/sumeru/main.go` → `sumeru/core/server` (`server.Run`). Library code under `core/` has no `main`.
 
 ## Prerequisites
 
-| Requirement | Notes |
-| ----------- | ----- |
-| [Go](https://go.dev/dl/) **1.26.2+** | See `go.mod` |
+| Requirement                               | Notes                |
+| ----------------------------------------- | -------------------- |
+| [Go](https://go.dev/dl/) **1.26.2+**      | See `go.mod`         |
 | [PostgreSQL](https://www.postgresql.org/) | Application database |
 
 ## Quick start (recommended)
@@ -103,29 +115,29 @@ INI format: `key = value` under **`[options]`**. Lines starting with `#` or `;` 
 
 Copy **`sumeru.conf.example`** → **`sumeru.conf`**.
 
-| Key | Use case |
-| --- | -------- |
-| `db_host`, `db_port` | PostgreSQL host and port |
-| `db_user`, `db_password` | Database credentials |
-| `db_name` | Database name (overridable with **`-d`** / **`--database`**) |
-| `db_sslmode` | PostgreSQL SSL mode (e.g. `disable` for local dev) |
-| `http_port` | HTTP listen port (default **8080**; overridable with **`-p`** / **`--http-port`**) |
-| `addons_path` | Comma-separated addon roots. Later roots **override** duplicate module names. Relative segments resolve from the INI directory. |
-| `sumeru_home` | Optional path to the standard **`sumeru`** checkout; default assets/templates when those keys are omitted |
-| `assets_path`, `templates_path` | Static files and HTML templates (defaults under `core/engine/…`) |
-| `logo_path` | Optional image; served at **`/static/app-logo`** |
-| `company_display_name`, `user_display_name` | Optional header labels |
-| `brand_css` | Optional extra CSS; linked as **`/static/brand.css`** |
-| `dev_mode` | Default **false**. When **true**, debug-level logs and dev-only behavior |
+| Key                                         | Use case                                                                                                                        |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `db_host`, `db_port`                        | PostgreSQL host and port                                                                                                        |
+| `db_user`, `db_password`                    | Database credentials                                                                                                            |
+| `db_name`                                   | Database name (overridable with **`-d`** / **`--database`**)                                                                    |
+| `db_sslmode`                                | PostgreSQL SSL mode (e.g. `disable` for local dev)                                                                              |
+| `http_port`                                 | HTTP listen port (default **8080**; overridable with **`-p`** / **`--http-port`**)                                              |
+| `addons_path`                               | Comma-separated addon roots. Later roots **override** duplicate module names. Relative segments resolve from the INI directory. |
+| `sumeru_home`                               | Optional path to the standard **`sumeru`** checkout; default assets/templates when those keys are omitted                       |
+| `assets_path`, `templates_path`             | Static files and HTML templates (defaults under `core/engine/…`)                                                                |
+| `logo_path`                                 | Optional image; served at **`/static/app-logo`**                                                                                |
+| `company_display_name`, `user_display_name` | Optional header labels                                                                                                          |
+| `brand_css`                                 | Optional extra CSS; linked as **`/static/brand.css`**                                                                           |
+| `dev_mode`                                  | Default **false**. When **true**, debug-level logs and dev-only behavior                                                        |
 
 **Logging:** `log_enabled`, `log_timezone`, `log_stdout`, `log_file`, `log_rolling`, and related rotation keys are documented in **`sumeru.conf.example`**.
 
 ### HTTP API
 
-| Endpoint | Use case |
-| -------- | -------- |
-| **`GET /api/health`** | Liveness; `{"ok":true}` (no auth) |
-| **`POST /api/rpc`** | JSON body `{"model","method","args","kwargs"}` with the session cookie. Methods: `search`, `search_read`, `read`, `create`, `write`, `unlink`. Optional Odoo-style `params` wrapper. |
+| Endpoint              | Use case                                                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`GET /api/health`** | Liveness; `{"ok":true}` (no auth)                                                                                                                                                    |
+| **`POST /api/rpc`**   | JSON body `{"model","method","args","kwargs"}` with the session cookie. Methods: `search`, `search_read`, `read`, `create`, `write`, `unlink`. Optional Odoo-style `params` wrapper. |
 
 ---
 
@@ -133,14 +145,14 @@ Copy **`sumeru.conf.example`** → **`sumeru.conf`**.
 
 All entrypoints (`go run ./cmd/sumeru --`, `./sumeru.sh`, `./sumeru`, and the custom-workspace `go run . --`) accept:
 
-| Flag | Use case |
-| ---- | -------- |
-| `-c <file>` | INI config path |
-| `-d <name>` / `--database <name>` | Override `db_name` (`--database` wins if both set) |
-| `-p <port>` / `--http-port <port>` | Override `http_port` (`-p` wins if both set) |
-| `-i mod1,mod2` | **Install** listed modules |
-| `-u mod1,mod2` or `-u all` | **Update** from disk; `all` = every installed module |
-| `--stop-after-init` | After `-i` / `-u`, exit without starting HTTP |
+| Flag                               | Use case                                             |
+| ---------------------------------- | ---------------------------------------------------- |
+| `-c <file>`                        | INI config path                                      |
+| `-d <name>` / `--database <name>`  | Override `db_name` (`--database` wins if both set)   |
+| `-p <port>` / `--http-port <port>` | Override `http_port` (`-p` wins if both set)         |
+| `-i mod1,mod2`                     | **Install** listed modules                           |
+| `-u mod1,mod2` or `-u all`         | **Update** from disk; `all` = every installed module |
+| `--stop-after-init`                | After `-i` / `-u`, exit without starting HTTP        |
 
 Examples:
 
@@ -157,47 +169,47 @@ Use **`-u`** after changing `views/*.xml`, `menus.xml`, or `manifest.json` data 
 
 ## Makefile (this repo)
 
-| Target | Use case |
-| ------ | -------- |
-| `make generate` | `go generate ./cmd/sumeru` — refresh `cmd/sumeru/zimports.go` from `sumeru.conf.example` |
-| `make run` | Generate, then `go run ./cmd/sumeru -- -c sumeru.conf` (optional `EXTRA_RUN_FLAGS`) |
-| `make build` | Generate, then `go build -o sumeru ./cmd/sumeru` |
-| `make bp NAME=my_module` | Scaffold a core-tree addon (`WITH_MODELS=1` optional) |
-| `make css` | Reminder: plain CSS under `core/engine/assets/css/` (no Sass build) |
-| `make help` | List targets |
+| Target                   | Use case                                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------------------- |
+| `make generate`          | `go generate ./cmd/sumeru`: refresh `cmd/sumeru/zimports.go` from `sumeru.conf.example` |
+| `make run`               | Generate, then `go run ./cmd/sumeru -- -c sumeru.conf` (optional `EXTRA_RUN_FLAGS`)      |
+| `make build`             | Generate, then `go build -o sumeru ./cmd/sumeru`                                         |
+| `make bp NAME=my_module` | Scaffold a core-tree addon (`WITH_MODELS=1` optional)                                    |
+| `make css`               | Reminder: plain CSS under `core/engine/assets/css/` (no Sass build)                      |
+| `make help`              | List targets                                                                             |
 
 In **`sumeru_custom_addons`**, use that repo’s Makefile (`make generate`, `make run`, `make replace-sumeru`, …) so imports are written under `addonimports/`, not into this tree.
 
 **`sumeru-import-gen`** (used by `go generate` / workspace `make generate`):
 
-| Flag | Default | Use case |
-| ---- | ------- | -------- |
-| `-root` | cwd walk-up | Standard `sumeru` repo root |
-| `-config` | `sumeru.conf.example` (via `go generate` in `cmd/sumeru`) | INI path |
-| `-out` | `cmd/sumeru/zimports.go` | Output file (absolute path when writing under custom workspace) |
-| `-package` | `main` | e.g. `addonimports` for the workspace |
+| Flag       | Default                                                   | Use case                                                        |
+| ---------- | --------------------------------------------------------- | --------------------------------------------------------------- |
+| `-root`    | cwd walk-up                                               | Standard `sumeru` repo root                                     |
+| `-config`  | `sumeru.conf.example` (via `go generate` in `cmd/sumeru`) | INI path                                                        |
+| `-out`     | `cmd/sumeru/zimports.go`                                  | Output file (absolute path when writing under custom workspace) |
+| `-package` | `main`                                                    | e.g. `addonimports` for the workspace                           |
 
 ---
 
 ## Project layout
 
-| Path | Use case |
-| ---- | -------- |
-| `core/orm/` | PostgreSQL-backed models, CRUD, registry |
-| `core/engine/` | Module XML, view inherit, HTML render, `templates/`, `assets/` |
-| `core/server/` | INI config, `run.go`, HTTP web handlers |
-| `core/module/` | Addon discovery, install/update, XML sync |
-| `core/sdk/` | **Stable Go API** for addons |
-| `core/server/router/` | Addon-extensible HTTP route registry |
-| `core/module/addon_template/` | Authoring reference for new addons |
-| `cmd/sumeru/` | Server `main` + generated `zimports.go` |
-| `cmd/sumeru-import-gen/` | Blank-import generator |
-| `cmd/sumeru-bp/` | Addon scaffold tool |
-| `addons/` | Kernel apps shipped with this repo |
-| `test/` | Unit and smoke tests (`go test ./...`) |
-| `sumeru.conf.example` | Tracked template + import-gen input |
-| `sumeru.sh` | Bash wrapper forwarding CLI flags |
-| `Makefile` | `generate`, `run`, `build`, `bp`, `help` |
+| Path                          | Use case                                                       |
+| ----------------------------- | -------------------------------------------------------------- |
+| `core/orm/`                   | PostgreSQL-backed models, CRUD, registry                       |
+| `core/engine/`                | Module XML, view inherit, HTML render, `templates/`, `assets/` |
+| `core/server/`                | INI config, `run.go`, HTTP web handlers                        |
+| `core/module/`                | Addon discovery, install/update, XML sync                      |
+| `core/sdk/`                   | **Stable Go API** for addons                                   |
+| `core/server/router/`         | Addon-extensible HTTP route registry                           |
+| `core/module/addon_template/` | Authoring reference for new addons                             |
+| `cmd/sumeru/`                 | Server `main` + generated `zimports.go`                        |
+| `cmd/sumeru-import-gen/`      | Blank-import generator                                         |
+| `cmd/sumeru-bp/`              | Addon scaffold tool                                            |
+| `addons/`                     | Kernel apps shipped with this repo                             |
+| `test/`                       | Unit and smoke tests (`go test ./...`)                         |
+| `sumeru.conf.example`         | Tracked template + import-gen input                            |
+| `sumeru.sh`                   | Bash wrapper forwarding CLI flags                              |
+| `Makefile`                    | `generate`, `run`, `build`, `bp`, `help`                       |
 
 ---
 
@@ -207,21 +219,21 @@ Styles are **plain CSS** under `core/engine/assets/css/` (layout uses `sum-*` cl
 
 **Canonical reference:** keep the global CSS file table below only in this README. Other docs should link here instead of duplicating the list.
 
-| File | Responsibility |
-| ---- | -------------- |
-| `sumeru-theme.css` | Branding tokens (`:root` colors, typography, radii, shadows) |
-| `sumeru-base.css` | Document defaults, scrollbars, `.sr-only`, etc. |
-| `sumeru-shell.css` | Top bar, sidebar, workspace grid, activity dock chrome |
-| `sumeru-messages.css` | Activity panel Messages tab |
-| `sumeru-views.css` | Form sheets, list tables, notebooks, field chrome |
-| `sumeru-compat.css` | Legacy `.field` blocks for login/setup templates |
-| `sumeru-ai.css` | Optional AI shell widget (`sumeru_ai`) |
-| `sumeru-login.css` | Standalone login card |
-| `sumeru-pages.css` | Standalone pages (e.g. app logs) |
-| `sumeru-apps.css` | `/web/apps` catalog (per-page) |
-| `sumeru-home.css` | `/web/home` (per-page) |
-| `sumeru-settings-hub.css` | `/web/settings` (per-page) |
-| `sumeru-workspace.css` | `/web` workspace extras |
+| File                      | Responsibility                                               |
+| ------------------------- | ------------------------------------------------------------ |
+| `sumeru-theme.css`        | Branding tokens (`:root` colors, typography, radii, shadows) |
+| `sumeru-base.css`         | Document defaults, scrollbars, `.sr-only`, etc.              |
+| `sumeru-shell.css`        | Top bar, sidebar, workspace grid, activity dock chrome       |
+| `sumeru-messages.css`     | Activity panel Messages tab                                  |
+| `sumeru-views.css`        | Form sheets, list tables, notebooks, field chrome            |
+| `sumeru-compat.css`       | Legacy `.field` blocks for login/setup templates             |
+| `sumeru-ai.css`           | Optional AI shell widget (`sumeru_ai`)                       |
+| `sumeru-login.css`        | Standalone login card                                        |
+| `sumeru-pages.css`        | Standalone pages (e.g. app logs)                             |
+| `sumeru-apps.css`         | `/web/apps` catalog (per-page)                               |
+| `sumeru-home.css`         | `/web/home` (per-page)                                       |
+| `sumeru-settings-hub.css` | `/web/settings` (per-page)                                   |
+| `sumeru-workspace.css`    | `/web` workspace extras                                      |
 
 Per-addon optional `static/css/theme-overrides.css` is served as `/static/addon-css/<module>.css`. Optional `brand_css` loads after those. Workspace HTML lives under `core/engine/render/`; templates under `core/engine/templates/`; client entry `core/engine/assets/js/core.js`.
 
@@ -229,12 +241,12 @@ Per-addon optional `static/css/theme-overrides.css` is served as `/static/addon-
 
 ## Documentation
 
-| Resource | Contents |
-| -------- | -------- |
-| This README | Setup, config, CLI, Makefile, CSS |
-| [`sumeru_addons/README.md`](https://github.com/ProjectMeru/sumeru_addons/blob/main/README.md) | Standard business addon module |
-| [`sumeru_custom_addons/README.md`](https://github.com/ProjectMeru/sumeru_custom_addons/blob/main/README.md) | Workspace runner, `make generate`, custom addons |
-| Sibling `docs/` (local workspace) | Developer guides and how-tos when checked out next to this repo (e.g. `../docs/developer/`) — not shipped inside this git tree |
+| Resource                                                                                                    | Contents                                                                                                                       |
+| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| This README                                                                                                 | Setup, config, CLI, Makefile, CSS                                                                                              |
+| [`sumeru_addons/README.md`](https://github.com/ProjectMeru/sumeru_addons/blob/main/README.md)               | Standard business addon module                                                                                                 |
+| [`sumeru_custom_addons/README.md`](https://github.com/ProjectMeru/sumeru_custom_addons/blob/main/README.md) | Workspace runner, `make generate`, custom addons                                                                               |
+| Sibling `docs/` (local workspace)                                                                           | Developer guides and how-tos when checked out next to this repo (e.g. `../docs/developer/`). Not shipped inside this git tree |
 
 ---
 
@@ -246,7 +258,7 @@ Please follow the **[Code of Conduct](CODE_OF_CONDUCT.md)**.
 
 ## Security
 
-Report vulnerabilities privately — see **[SECURITY.md](SECURITY.md)**. Do not open public issues for undisclosed security problems.
+Report vulnerabilities privately. See **[SECURITY.md](SECURITY.md)**. Do not open public issues for undisclosed security problems.
 
 ## License
 

--- a/addons/automation/init.go
+++ b/addons/automation/init.go
@@ -16,7 +16,7 @@ func init() {
 	event.Subscribe("cron.tick", runServerActionsForEvent)
 }
 
-// WIP: server-action code execution is not implemented; matching rows are logged only.
+// TODO: run server actions (log matches for now)
 func runServerActionsForEvent(ctx context.Context, ev event.Event) error {
 	if orm.DB == nil {
 		return nil

--- a/addons/base/models/core_city.go
+++ b/addons/base/models/core_city.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// CoreCity is a city linked to a country and optional state.
 type CoreCity struct {
 	sdk.BaseModel
 }

--- a/addons/base/models/core_country.go
+++ b/addons/base/models/core_country.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// CoreCountry is a geographic country with calling code.
 type CoreCountry struct {
 	sdk.BaseModel
 }

--- a/addons/base/models/core_country_state.go
+++ b/addons/base/models/core_country_state.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// CoreCountryState is a state/province/region within a country.
 type CoreCountryState struct {
 	sdk.BaseModel
 }

--- a/addons/base/models/core_group.go
+++ b/addons/base/models/core_group.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// CoreGroup is the core.group access-group model (users belong via core.group.user.rel).
 type CoreGroup struct {
 	sdk.BaseModel
 	Name        string `db:"name"`

--- a/addons/base/models/core_lang.go
+++ b/addons/base/models/core_lang.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// CoreLang is an installable language catalog entry.
 type CoreLang struct {
 	sdk.BaseModel
 	Code    string `db:"code"`

--- a/addons/base/models/core_partner.go
+++ b/addons/base/models/core_partner.go
@@ -25,6 +25,8 @@ func (p Partner) Fields() []sdk.FieldDefinition {
 		{Name: "comment", Type: sdk.Text, String: "Notes"},
 		{Name: "is_company", Type: sdk.Boolean, String: "Is a Company"},
 		{Name: "active", Type: sdk.Boolean, String: "Active", DefaultVal: true},
+		{Name: "property_account_receivable_id", Type: sdk.Many2One, Relation: "account.account", String: "Receivable Account"},
+		{Name: "property_account_payable_id", Type: sdk.Many2One, Relation: "account.account", String: "Payable Account"},
 	}
 }
 

--- a/addons/base/models/core_user_apikey.go
+++ b/addons/base/models/core_user_apikey.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// CoreUserAPIKey stores hashed API keys for external RPC auth (model: core.user.apikey).
 type CoreUserAPIKey struct {
 	sdk.BaseModel
 	UserID     int    `db:"user_id"`

--- a/addons/base/models/core_user_log.go
+++ b/addons/base/models/core_user_log.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// CoreUserLog records successful (and optionally failed) logins.
 type CoreUserLog struct {
 	sdk.BaseModel
 	UserID     int    `db:"user_id"`

--- a/addons/base/models/sys_attachment.go
+++ b/addons/base/models/sys_attachment.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// SysAttachment stores file metadata (content as base64/text or path).
 type SysAttachment struct {
 	sdk.BaseModel
 	Name       string `db:"name"`

--- a/addons/base/models/sys_audit.go
+++ b/addons/base/models/sys_audit.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// SysAudit is an append-only audit trail (before/after JSON).
 type SysAudit struct {
 	sdk.BaseModel
 	UserID     int    `db:"user_id"`

--- a/addons/base/models/sys_config_parameter.go
+++ b/addons/base/models/sys_config_parameter.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// SysConfigParameter is a key/value system setting.
 type SysConfigParameter struct {
 	sdk.BaseModel
 	Key   string `db:"key"`

--- a/addons/base/models/sys_field_access.go
+++ b/addons/base/models/sys_field_access.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// SysFieldAccess is optional field-level security (read/write per group).
 type SysFieldAccess struct {
 	sdk.BaseModel
 	Name      string `db:"name"`

--- a/addons/base/models/sys_sequence.go
+++ b/addons/base/models/sys_sequence.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// SysSequence generates monotonic document numbers.
 type SysSequence struct {
 	sdk.BaseModel
 	Name       string `db:"name"`

--- a/addons/base/models/sys_translation.go
+++ b/addons/base/models/sys_translation.go
@@ -2,7 +2,6 @@ package models
 
 import "sumeru/core/sdk"
 
-// SysTranslation stores a translated term for a language.
 type SysTranslation struct {
 	sdk.BaseModel
 	Lang   string `db:"lang"`

--- a/addons/contacts/views/core_partner_form_views.xml
+++ b/addons/contacts/views/core_partner_form_views.xml
@@ -5,26 +5,27 @@
             <sheet>
                 <div class="sum_title">
                     <h1>
-                        <field name="name" placeholder="Contact or Company Name..."/>
+                        <field name="name" placeholder="Contact or Company Name..." />
                     </h1>
                 </div>
                 <group>
                     <group string="Contact">
-                        <field name="email" string="Email"/>
-                        <field name="phone" string="Phone"/>
-                        <field name="is_company" string="Is a Company"/>
-                        <field name="active" string="Active"/>
+                        <field name="email" string="Email" />
+                        <field name="phone" string="Phone" />
+                        <field name="is_company" string="Is a Company" />
+                        <field name="active" string="Active" />
                     </group>
                     <group string="Address">
-                        <field name="street" string="Street"/>
-                        <field name="country_id" string="Country" widget="selection"/>
-                        <field name="state_id" string="State" widget="selection"/>
-                        <field name="city_id" string="City" widget="selection"/>
+                        <field name="street" string="Street" />
+                        <field name="country_id" string="Country" widget="selection" />
+                        <field name="state_id" string="State" widget="selection" />
+                        <field name="city_id" string="City" widget="selection" />
                     </group>
                 </group>
                 <notebook>
                     <page string="Notes" name="notes">
-                        <field name="comment" string="Internal Notes" placeholder="Internal notes..."/>
+                        <field name="comment" string="Internal Notes"
+                            placeholder="Internal notes..." />
                     </page>
                 </notebook>
             </sheet>

--- a/addons/mail/mail.go
+++ b/addons/mail/mail.go
@@ -18,7 +18,6 @@ const (
 	SubtypeModule       = "module"
 )
 
-// Row is one persisted message (subset of columns used by UI and hooks).
 type Row struct {
 	Body       string
 	Subtype    string

--- a/core/engine/assets/css/sumeru-views.css
+++ b/core/engine/assets/css/sumeru-views.css
@@ -50,6 +50,7 @@
 .sum-form-view .sum-form-sheet {
 	width: 100%;
 	max-width: 100%;
+	min-width: 0;
 	margin: 0.75rem 0;
 	padding: 1.25rem 1.5rem 2rem;
 	background: var(--sum-surface);
@@ -57,8 +58,14 @@
 	box-shadow: var(--sum-shadow-md), 0 0 0 1px rgba(255, 255, 255, 0.5) inset;
 	border: 1px solid var(--sum-line);
 	box-sizing: border-box;
+	overflow-x: auto;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
+}
+
+.sum-form-view .sum-form-sheet > * {
+	min-width: 0;
+	max-width: 100%;
 }
 
 .sum-form-sheet-bg {
@@ -73,9 +80,11 @@
 }
 
 .sum-form-page-grid,
-.sum-form-group-grid {
+.sum-form-group-grid,
+.sum-form-edit-grid {
 	box-sizing: border-box;
 	min-width: 0;
+	max-width: 100%;
 }
 
 .sum-form-view--readonly .sum-form-sheet {
@@ -128,6 +137,9 @@
   border-radius: var(--sum-radius-sm);
   background: var(--sum-surface);
   box-shadow: var(--sum-shadow-sm);
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .sum-notebook-tabs {
@@ -224,6 +236,8 @@
 .sum-form-sheet-bg {
   flex: 1 1 auto;
   min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   padding: 1rem 0.75rem 1.5rem;
 }
@@ -343,6 +357,8 @@
 
 .sum-form-title-body--main {
   margin-bottom: 1rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .sum-form-hero-input--bold {
@@ -475,12 +491,16 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+  min-width: 0;
 }
 
 .sum-form-edit-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1.5rem;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
 }
 
 @media (min-width: 768px) {
@@ -491,11 +511,15 @@
 }
 
 .sum-read-section {
+  box-sizing: border-box;
+  min-width: 0;
+  max-width: 100%;
   margin-bottom: 1.5rem;
   padding: 1rem 1.25rem;
   border-radius: var(--sum-radius-sm);
   border: 1px solid var(--sum-line);
   background: color-mix(in srgb, var(--sum-surface) 92%, var(--sum-bg));
+  overflow: hidden;
 }
 
 .sum-read-section-title {
@@ -532,7 +556,9 @@
 }
 
 .sum-form-hero-input {
+  box-sizing: border-box;
   width: 100%;
+  max-width: 100%;
   margin-bottom: 1rem;
   padding-bottom: 0.25rem;
   font-size: clamp(1.5rem, 4vw, 2.25rem);
@@ -554,7 +580,9 @@
 }
 
 .sum-form-inline-input {
+  box-sizing: border-box;
   width: 100%;
+  max-width: 100%;
   padding: 0.15rem 0;
   font-size: var(--sum-font-size-root);
   color: var(--sum-muted-ink);
@@ -792,18 +820,37 @@
 }
 
 .sum-form-group {
+  box-sizing: border-box;
+  min-width: 0;
+  max-width: 100%;
   border: 1px solid var(--sum-line);
   border-radius: var(--sum-radius-sm);
   padding: 1rem 1.15rem 1.1rem;
   margin-bottom: 1.25rem;
   background: color-mix(in srgb, var(--sum-surface) 97%, var(--sum-bg));
+  overflow: hidden;
 }
 
-.sum-form-group--full,
-.sum-read-section--full,
+.sum-form-edit-grid > .sum-form-group--full,
+.sum-form-page-grid > .sum-form-group--full,
+.sum-read-fields--sheet > .sum-read-section--full {
+  grid-column: 1 / -1;
+  max-width: 100%;
+}
+
+.sum-form-group-grid > .sum-form-group--full {
+  grid-column: auto;
+  max-width: 100%;
+}
+
+.sum-read-fields > .sum-read-section--full {
+  grid-column: auto;
+  max-width: 100%;
+}
+
 .sum-field-widget--full {
   grid-column: 1 / -1;
-  width: 100%;
+  max-width: 100%;
 }
 
 .sum-form-group--plain {
@@ -811,6 +858,7 @@
   background: transparent;
   padding-left: 0;
   padding-right: 0;
+  overflow: visible;
 }
 
 .sum-form-sheet {
@@ -933,6 +981,9 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem 1.5rem;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
 }
 
 @media (min-width: 768px) {

--- a/core/engine/parser/arch_multiroot.go
+++ b/core/engine/parser/arch_multiroot.go
@@ -30,7 +30,7 @@ type archKanbanRoot struct {
 	Field   []Field  `xml:"field"`
 }
 
-// promoteNestedForm lifts children of an Odoo-style nested <form> onto View so
+// promoteNestedForm lifts children of a nested <form> under <view> onto View so
 // sheet/header/fields are not lost when XML is <view><form><sheet>…</sheet></form></view>.
 func promoteNestedForm(v *View) {
 	if v == nil || !formArchHasContent(v.Form) {

--- a/core/engine/parser/doc.go
+++ b/core/engine/parser/doc.go
@@ -1,6 +1,2 @@
-// Package parser converts addon XML and related files into structured Go values (views, records, menus).
-//
-// Dependency rules (keep this package easy to test and reuse):
-//   - Do not import sumeru/core/orm, sumeru/core/server, or sumeru/core/engine/render.
-//   - I/O is limited to reading files passed in by callers; no database or HTTP.
+// Package parser converts addon XML and related files into structured Go values.
 package parser

--- a/core/engine/parser/view_xml.go
+++ b/core/engine/parser/view_xml.go
@@ -23,7 +23,7 @@ type View struct {
 	Chatter       *Chatter `xml:"chatter"`
 	Field         []Field  `xml:"field"`
 	Group         []Group  `xml:"group"`
-	// Form is an Odoo-style nested <form> under <view>; promoted onto View then cleared.
+	// Form is a nested <form> under <view>; promoted onto View then cleared.
 	Form *archFormRoot `xml:"form"`
 }
 

--- a/core/engine/render/activity_chatter_render.go
+++ b/core/engine/render/activity_chatter_render.go
@@ -12,7 +12,6 @@ import (
 	"sumeru/addons/mail"
 )
 
-// writeActivityChatterPanel renders thread + composer for the right activity panel (comments only).
 func writeActivityChatterPanel(ctx context.Context, sb *strings.Builder, c *parser.Chatter, vr *ViewRecordData, viewModel string) {
 	_ = c
 	if !mail.CompanyChatterEnabled(ctx) || vr == nil || vr.RecordID <= 0 {

--- a/core/engine/render/doc.go
+++ b/core/engine/render/doc.go
@@ -1,9 +1,2 @@
-// Package render builds workspace HTML from parser views and ORM-backed record data.
-//
-// Dependency rules:
-//   - Do not import sumeru/core/server/web (avoid render ↔ HTTP cycles). Pass URLs, flags, and
-//     branding through PageData and related structs instead of reaching into handlers.
-//   - sumeru/core/engine/parser is the source for view XML shapes.
-//   - sumeru/core/orm is allowed for display-oriented reads that already exist in templates/helpers.
-//   - Prefer keeping new configuration on PageData over new imports from sumeru/core/server/… .
+// Package render builds workspace HTML from views and ORM data.
 package render

--- a/core/engine/render/form_chrome.go
+++ b/core/engine/render/form_chrome.go
@@ -61,8 +61,6 @@ func renderButtonBox(sb *strings.Builder, d parser.Div) {
 	sb.WriteString(`<div class="sum-form-toolbar-spacer" aria-hidden="true"></div>`)
 }
 
-// renderTitleAvatar renders only the compact profile/logo avatar for the split left rail.
-// Upload controls are shown only when the model defines an "image" field.
 func renderTitleAvatar(ctx context.Context, sb *strings.Builder, d parser.Div, record map[string]interface{}, ro bool, resModel string) {
 	_ = ctx
 	_ = d
@@ -93,7 +91,6 @@ func renderTitleAvatar(ctx context.Context, sb *strings.Builder, d parser.Div, r
 	sb.WriteString(`</div>`)
 }
 
-// renderTitleBody renders bold name + contact fields for the main column header.
 func renderTitleBody(ctx context.Context, sb *strings.Builder, d parser.Div, record map[string]interface{}, ro bool) {
 	_ = ctx
 	sb.WriteString(`<div class="sum-form-title-body sum-form-title-body--main">`)
@@ -155,7 +152,6 @@ func renderTitleBody(ctx context.Context, sb *strings.Builder, d parser.Div, rec
 	sb.WriteString(`</div>`)
 }
 
-// renderTitle keeps a combined title row for non-split layouts.
 func renderTitle(ctx context.Context, sb *strings.Builder, d parser.Div, record map[string]interface{}, ro bool, resModel string) {
 	sb.WriteString(`<div class="sum-form-title-row sum-form-title-row--sheet">`)
 	renderTitleAvatar(ctx, sb, d, record, ro, resModel)

--- a/core/engine/render/form_chrome.go
+++ b/core/engine/render/form_chrome.go
@@ -9,18 +9,24 @@ import (
 	"sumeru/core/engine/parser"
 )
 
-func renderHeader(ctx context.Context, sb *strings.Builder, h *parser.Header, record map[string]interface{}) {
+func renderHeader(ctx context.Context, sb *strings.Builder, h *parser.Header, record map[string]interface{}, vr *ViewRecordData) {
 	_ = ctx
 	sb.WriteString(`<div class="sum-form-statusbar">`)
 
 	if len(h.Button) > 0 {
 		sb.WriteString(`<div class="sum-statusbar-buttons">`)
-		for _, b := range h.Button {
-			class := "sum-header-btn sum-header-btn--secondary sum-header-btn--disabled"
-			if b.Class == "sum_highlight" {
-				class = "sum-header-btn sum-header-btn--primary sum-header-btn--disabled"
+		model := ""
+		id := 0
+		next := ""
+		if vr != nil {
+			model = strings.TrimSpace(vr.ResModel)
+			id = vr.RecordID
+			if q := strings.TrimSpace(vr.FormBaseQuery); q != "" {
+				next = "/web?" + q
 			}
-			sb.WriteString(fmt.Sprintf(`<button type="button" disabled class="%s" title="Not available yet">%s</button>`, class, template.HTMLEscapeString(b.String)))
+		}
+		for _, b := range h.Button {
+			writeObjectActionButton(sb, b, model, id, next, false)
 		}
 		sb.WriteString(`</div>`)
 	}
@@ -157,22 +163,23 @@ func renderTitle(ctx context.Context, sb *strings.Builder, d parser.Div, record 
 	sb.WriteString(`</div>`)
 }
 
-func renderFormFooter(sb *strings.Builder, ft *parser.Footer) {
+func renderFormFooter(sb *strings.Builder, ft *parser.Footer, vr *ViewRecordData) {
 	if ft == nil || len(ft.Button) == 0 {
 		return
 	}
+	model := ""
+	id := 0
+	next := ""
+	if vr != nil {
+		model = strings.TrimSpace(vr.ResModel)
+		id = vr.RecordID
+		if q := strings.TrimSpace(vr.FormBaseQuery); q != "" {
+			next = "/web?" + q
+		}
+	}
 	sb.WriteString(`<div class="sum-form-footer" role="group" aria-label="Form actions">`)
 	for _, b := range ft.Button {
-		btnClass := "sum-form-footer-btn"
-		if strings.Contains(b.Class, "sum_highlight") || strings.Contains(b.Class, "btn-primary") {
-			btnClass += " sum-form-footer-btn--primary"
-		}
-		label := template.HTMLEscapeString(b.String)
-		if label == "" {
-			label = template.HTMLEscapeString(b.Name)
-		}
-		sb.WriteString(fmt.Sprintf(`<button type="button" disabled name="%s" class="%s" aria-disabled="true">%s</button>`,
-			template.HTMLEscapeString(b.Name), btnClass, label))
+		writeObjectActionButton(sb, b, model, id, next, true)
 	}
 	sb.WriteString(`</div>`)
 }

--- a/core/engine/render/form_chrome.go
+++ b/core/engine/render/form_chrome.go
@@ -154,7 +154,9 @@ func renderTitleBody(ctx context.Context, sb *strings.Builder, d parser.Div, rec
 
 func renderTitle(ctx context.Context, sb *strings.Builder, d parser.Div, record map[string]interface{}, ro bool, resModel string) {
 	sb.WriteString(`<div class="sum-form-title-row sum-form-title-row--sheet">`)
-	renderTitleAvatar(ctx, sb, d, record, ro, resModel)
+	if fieldDef(resModel, "image") != nil {
+		renderTitleAvatar(ctx, sb, d, record, ro, resModel)
+	}
 	renderTitleBody(ctx, sb, d, record, ro)
 	sb.WriteString(`</div>`)
 }

--- a/core/engine/render/form_layout.go
+++ b/core/engine/render/form_layout.go
@@ -34,22 +34,26 @@ func renderSheet(ctx context.Context, sb *strings.Builder, s *parser.Sheet, reco
 		}
 	}
 
+	resModel := ""
+	if vr != nil {
+		resModel = strings.TrimSpace(vr.ResModel)
+	}
+	showAvatar := fieldDef(resModel, "image") != nil
+	usedSplit := false
+
 	if hasSumTitle && titleDiv != nil {
-		sb.WriteString(`<div class="sum-form-split-layout sum-form-split-layout--compact" data-sum-form-split>`)
-		sb.WriteString(`<aside class="sum-form-split-left sum-form-split-left--avatar" aria-label="Profile picture">`)
-		resModel := ""
-		if vr != nil {
-			resModel = strings.TrimSpace(vr.ResModel)
+		if showAvatar {
+			usedSplit = true
+			sb.WriteString(`<div class="sum-form-split-layout sum-form-split-layout--compact" data-sum-form-split>`)
+			sb.WriteString(`<aside class="sum-form-split-left sum-form-split-left--avatar" aria-label="Profile picture">`)
+			renderTitleAvatar(ctx, sb, *titleDiv, record, ro, resModel)
+			sb.WriteString(`</aside>`)
+			sb.WriteString(`<div class="sum-form-split-main">`)
+			renderTitleBody(ctx, sb, *titleDiv, record, ro)
+		} else {
+			renderTitleBody(ctx, sb, *titleDiv, record, ro)
 		}
-		renderTitleAvatar(ctx, sb, *titleDiv, record, ro, resModel)
-		sb.WriteString(`</aside>`)
-		sb.WriteString(`<div class="sum-form-split-main">`)
-		renderTitleBody(ctx, sb, *titleDiv, record, ro)
 	} else if titleDiv != nil {
-		resModel := ""
-		if vr != nil {
-			resModel = strings.TrimSpace(vr.ResModel)
-		}
 		renderTitle(ctx, sb, *titleDiv, record, ro, resModel)
 	}
 
@@ -76,7 +80,7 @@ func renderSheet(ctx context.Context, sb *strings.Builder, s *parser.Sheet, reco
 		renderNotebook(ctx, sb, nb, record, ro, vr)
 	}
 
-	if hasSumTitle {
+	if usedSplit {
 		sb.WriteString(`</div></div>`)
 	}
 

--- a/core/engine/render/form_render.go
+++ b/core/engine/render/form_render.go
@@ -7,7 +7,6 @@ import (
 	"sumeru/core/engine/parser"
 )
 
-// RenderForm renders a parsed form view into HTML (sheet, header, fields, notebooks).
 func RenderForm(ctx context.Context, view *parser.View, vr *ViewRecordData) string {
 	if vr == nil {
 		vr = &ViewRecordData{}

--- a/core/engine/render/form_render.go
+++ b/core/engine/render/form_render.go
@@ -35,7 +35,7 @@ func RenderForm(ctx context.Context, view *parser.View, vr *ViewRecordData) stri
 	if chrome {
 		renderWorkspaceFormToolbar(&sb, vr, view.Header, record)
 	} else if view.Header != nil {
-		renderHeader(ctx, &sb, view.Header, record)
+		renderHeader(ctx, &sb, view.Header, record, vr)
 	}
 
 	if view.Sheet != nil {
@@ -52,7 +52,7 @@ func RenderForm(ctx context.Context, view *parser.View, vr *ViewRecordData) stri
 	}
 
 	if view.Footer != nil {
-		renderFormFooter(&sb, view.Footer)
+		renderFormFooter(&sb, view.Footer, vr)
 	}
 
 	if chrome {

--- a/core/engine/render/form_widgets.go
+++ b/core/engine/render/form_widgets.go
@@ -188,7 +188,6 @@ func imageSrcOK(src string) bool {
 	return src != "" && (strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") || strings.HasPrefix(src, "data:"))
 }
 
-// renderImageField renders widget="image" with upload controls (data-URL via JS).
 func renderImageField(sb *strings.Builder, f parser.Field, label string, record map[string]interface{}, ro bool) {
 	src := strings.TrimSpace(recStr(record, f.Name))
 	if ro {
@@ -245,9 +244,6 @@ func fieldDef(modelName, fieldName string) *orm.FieldDefinition {
 
 func renderTypedInput(sb *strings.Builder, f parser.Field, label string, record map[string]interface{}, ro bool, inputType string) {
 	placeholder := f.Placeholder
-	if placeholder == "" {
-		placeholder = "Enter " + strings.ToLower(label) + "..."
-	}
 	val := recStr(record, f.Name)
 	if ro {
 		display := val
@@ -283,9 +279,6 @@ func renderTextareaField(sb *strings.Builder, f parser.Field, label string, reco
 		return
 	}
 	placeholder := f.Placeholder
-	if placeholder == "" {
-		placeholder = "Enter " + strings.ToLower(label) + "..."
-	}
 	sb.WriteString(`<div class="sum-field-widget sum-field-widget--full">`)
 	sb.WriteString(`<label class="sum-field-label" for="` + template.HTMLEscapeString(f.Name) + `">` + template.HTMLEscapeString(label) + `</label>`)
 	sb.WriteString(fmt.Sprintf(`<textarea class="sum-field-input sum-field-textarea" id="%s" name="%s" rows="4" placeholder="%s">%s</textarea>`,
@@ -329,7 +322,6 @@ func renderMany2OneField(ctx context.Context, sb *strings.Builder, f parser.Fiel
 	sb.WriteString(`</div>`)
 }
 
-// cascadeParentForField returns the parent field name used to filter dropdown options.
 func cascadeParentForField(fieldName string) (parent string, fallback string) {
 	switch fieldName {
 	case "state_id":

--- a/core/engine/render/form_widgets.go
+++ b/core/engine/render/form_widgets.go
@@ -56,9 +56,6 @@ func renderField(ctx context.Context, sb *strings.Builder, f parser.Field, recor
 				renderModelSelectionSelect(sb, f, label, record, ro, fd.Selection)
 				return
 			}
-		case orm.Boolean:
-			renderBooleanSelect(sb, f, label, record, ro)
-			return
 		}
 	}
 
@@ -134,9 +131,13 @@ func renderBooleanField(sb *strings.Builder, f parser.Field, label string, recor
 }
 
 func renderBooleanSelect(sb *strings.Builder, f parser.Field, label string, truthy bool) {
+	trueLabel, falseLabel := "Yes", "No"
+	if f.Name == "active" {
+		trueLabel, falseLabel = "Active", "Inactive"
+	}
 	renderSelectShell(sb, f, label, false, false, func() {
-		writeOption(sb, "true", "Yes", truthy, false)
-		writeOption(sb, "false", "No", !truthy, false)
+		writeOption(sb, "true", trueLabel, truthy, false)
+		writeOption(sb, "false", falseLabel, !truthy, false)
 	})
 }
 
@@ -180,34 +181,6 @@ func renderModelSelectionSelect(sb *strings.Builder, f parser.Field, label strin
 			}
 			writeOption(sb, o[0], o[1], o[0] == cur, false)
 		}
-	})
-}
-
-// renderBooleanSelect renders Boolean fields as a Yes/No (or Active/Inactive) dropdown.
-func renderBooleanSelect(sb *strings.Builder, f parser.Field, label string, record map[string]interface{}, ro bool) {
-	raw, hasRaw := rawField(record, f.Name)
-	truthy := hasRaw && isTruthyDB(raw)
-	// New records with no value: honor common DefaultVal-like UX for active-style fields.
-	if !hasRaw && f.Name == "active" {
-		truthy = true
-	}
-
-	trueLabel, falseLabel := "Yes", "No"
-	if f.Name == "active" {
-		trueLabel, falseLabel = "Active", "Inactive"
-	}
-
-	renderSelectShell(sb, f, label, ro, false, func() {
-		if ro {
-			if truthy {
-				sb.WriteString(template.HTMLEscapeString(trueLabel))
-			} else {
-				sb.WriteString(template.HTMLEscapeString(falseLabel))
-			}
-			return
-		}
-		writeOption(sb, "true", trueLabel, truthy, false)
-		writeOption(sb, "false", falseLabel, !truthy, false)
 	})
 }
 

--- a/core/engine/render/kanban_render.go
+++ b/core/engine/render/kanban_render.go
@@ -50,7 +50,6 @@ func formatKanbanFieldValue(ctx context.Context, model, name string, row map[str
 	}
 }
 
-// RenderKanban renders a simple kanban board for workspace views.
 func RenderKanban(ctx context.Context, view *parser.View, rows []map[string]interface{}, actionID int, menuID string) string {
 	if rows == nil {
 		rows = []map[string]interface{}{}

--- a/core/engine/render/menu_breadcrumb.go
+++ b/core/engine/render/menu_breadcrumb.go
@@ -10,7 +10,6 @@ import (
 	"sumeru/core/orm"
 )
 
-// BreadcrumbItem is one segment in the shell breadcrumb trail.
 type BreadcrumbItem struct {
 	Label string
 	Href  string // empty = current page (no link)

--- a/core/engine/render/menus.go
+++ b/core/engine/render/menus.go
@@ -24,12 +24,6 @@ func sanitizeMenuIcon(s string) string {
 	return ""
 }
 
-// LoadShellMenus loads sys.menu rows for installed modules and derives top bar + sidebar structure.
-// Top bar: one entry per installed application module (sys.module.application = true), ordered by each
-// root menuitem's sequence (then name), like Sumeru XML. A root named "Settings" is omitted here because
-// base.html always renders a pinned link to /web/settings (second-to-last); Apps is always last.
-// Sidebar: menus under the active app root (may span modules, e.g. Settings).
-// shellModuleTitle is the active root menu label for breadcrumbs (works even when that root is not in TopMenus).
 func LoadShellMenus(ctx context.Context, activeMenuID string) (topMenus []parser.MenuItem, sidebarMenus []SidebarMenu, activeModuleID, shellModuleTitle string) {
 	shellModuleTitle = AppDisplayName
 	modTbl := orm.GetTableName("sys.module")

--- a/core/engine/render/object_action_buttons.go
+++ b/core/engine/render/object_action_buttons.go
@@ -1,0 +1,79 @@
+package render
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+
+	"sumeru/core/engine/parser"
+)
+
+func writeObjectActionButtons(sb *strings.Builder, header *parser.Header, vr *ViewRecordData, nextURL string) {
+	if header == nil || vr == nil || vr.RecordID <= 0 {
+		return
+	}
+	for _, b := range header.Button {
+		writeObjectActionButton(sb, b, vr.ResModel, vr.RecordID, nextURL, false)
+	}
+}
+
+func writeObjectActionButton(sb *strings.Builder, b parser.Button, model string, id int, nextURL string, insideForm bool) {
+	label := strings.TrimSpace(b.String)
+	if label == "" {
+		label = strings.TrimSpace(b.Name)
+	}
+	class := "sum-header-btn sum-header-btn--secondary"
+	if strings.Contains(b.Class, "sum_highlight") || strings.Contains(b.Class, "btn-primary") {
+		class = "sum-header-btn sum-header-btn--primary"
+	}
+	if strings.Contains(b.Class, "sum-form-footer-btn") || insideForm {
+		class = "sum-form-footer-btn"
+		if strings.Contains(b.Class, "sum_highlight") || strings.Contains(b.Class, "btn-primary") {
+			class += " sum-form-footer-btn--primary"
+		}
+	}
+	btnType := strings.ToLower(strings.TrimSpace(b.Type))
+	method := strings.TrimSpace(b.Name)
+	if (btnType == "object" || btnType == "") && method != "" && model != "" && id > 0 {
+		if insideForm {
+			// Submit parent record form to object action so edited fields are included.
+			sb.WriteString(fmt.Sprintf(
+				`<button type="submit" formaction="/web/action/object" formmethod="post" name="method" value="%s" class="%s">%s</button>`,
+				template.HTMLEscapeString(method), class, template.HTMLEscapeString(label),
+			))
+			return
+		}
+		formID := fmt.Sprintf("sum-obj-act-%s-%d", sanitizeFormID(method), id)
+		sb.WriteString(fmt.Sprintf(
+			`<form id="%s" method="post" action="/web/action/object" class="sum-object-action-form" style="display:inline">`,
+			template.HTMLEscapeString(formID),
+		))
+		sb.WriteString(`<input type="hidden" name="model" value="` + template.HTMLEscapeString(model) + `" />`)
+		sb.WriteString(fmt.Sprintf(`<input type="hidden" name="id" value="%d" />`, id))
+		sb.WriteString(`<input type="hidden" name="method" value="` + template.HTMLEscapeString(method) + `" />`)
+		if nextURL != "" {
+			sb.WriteString(`<input type="hidden" name="next" value="` + template.HTMLEscapeString(nextURL) + `" />`)
+		}
+		sb.WriteString(fmt.Sprintf(`<button type="submit" class="%s">%s</button>`, class, template.HTMLEscapeString(label)))
+		sb.WriteString(`</form>`)
+		return
+	}
+	sb.WriteString(fmt.Sprintf(`<button type="button" disabled class="%s sum-header-btn--disabled" title="Action unavailable">%s</button>`,
+		class, template.HTMLEscapeString(label)))
+}
+
+func sanitizeFormID(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "act"
+	}
+	return out
+}

--- a/core/engine/render/pivot_render.go
+++ b/core/engine/render/pivot_render.go
@@ -7,8 +7,7 @@ import (
 	"sumeru/core/engine/parser"
 )
 
-// RenderPivot renders a placeholder for pivot views.
-// WIP: full pivot analytics rendering is not implemented.
+// TODO: pivot view
 func RenderPivot(_ context.Context, _ *parser.View) string {
 	var sb strings.Builder
 	sb.WriteString(`<div class="sum-pivot-placeholder">`)

--- a/core/engine/render/render_types.go
+++ b/core/engine/render/render_types.go
@@ -32,7 +32,6 @@ func RegisterNotebookHook(model, pageTitle string, hook UIHook) {
 	NotebookHooks[model][strings.ToLower(pageTitle)] = hook
 }
 
-// ShellCompanyOption is one row in the shell company switcher.
 type ShellCompanyOption struct {
 	ID   int
 	Name string
@@ -91,7 +90,6 @@ type PageData struct {
 	ActivityChatterHTML     template.HTML
 }
 
-// ActivityItem is one line in the shell activity feed.
 type ActivityItem struct {
 	Meta string // author · relative time
 	Body string

--- a/core/engine/render/tree_render.go
+++ b/core/engine/render/tree_render.go
@@ -11,7 +11,6 @@ import (
 	"sumeru/core/orm"
 )
 
-// RenderTree renders list/tree HTML for workspace views.
 func RenderTree(ctx context.Context, view *parser.View, rows []map[string]interface{}, actionID int, menuID string) string {
 	if rows == nil {
 		rows = []map[string]interface{}{}

--- a/core/engine/render/workspace_chrome.go
+++ b/core/engine/render/workspace_chrome.go
@@ -56,15 +56,7 @@ func renderWorkspaceFormToolbar(sb *strings.Builder, vr *ViewRecordData, header 
 	}
 
 	if header != nil {
-		for _, b := range header.Button {
-			class := "sum-header-btn "
-			if b.Class == "sum_highlight" {
-				class += "sum-header-btn--primary"
-			} else {
-				class += "sum-header-btn--secondary"
-			}
-			sb.WriteString(fmt.Sprintf(`<button type="button" disabled class="%s sum-header-btn--disabled">%s</button>`, class, template.HTMLEscapeString(b.String)))
-		}
+		writeObjectActionButtons(sb, header, vr, cancelURL)
 	}
 
 	sb.WriteString(`</div>`)

--- a/core/engine/render/workspace_toolbar.go
+++ b/core/engine/render/workspace_toolbar.go
@@ -9,7 +9,6 @@ import (
 	"sumeru/core/orm"
 )
 
-// ViewSwitchTab is one entry in the workspace view switcher (list / kanban / form).
 type ViewSwitchTab struct {
 	Label  string
 	Href   string

--- a/core/engine/viewinherit/xpath.go
+++ b/core/engine/viewinherit/xpath.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 )
 
-// xpathOp is one xpath directive from an inherit arch fragment.
 type xpathOp struct {
 	Expr     string
 	Position string

--- a/core/module/data_sync_records.go
+++ b/core/module/data_sync_records.go
@@ -56,22 +56,38 @@ func syncRegistryRecordByModel(ctx context.Context, moduleName string, xmlRecord
 	switch xmlRecord.Model {
 	case "core.user":
 		conflictColumn = "login"
-	case "core.country", "core.lang":
+	case "core.country", "core.lang", "account.account":
 		conflictColumn = "code"
-	case "core.country.state", "core.city":
+	case "core.country.state", "core.city", "account.tax", "account.payment.term",
+		"account.move", "account.move.line", "core.partner", "account.journal":
 		conflictColumn = ""
 	}
 
-	// States/cities: match existing row by name + country (and state for cities) so -u
-	// after deleteModuleMetadata does not insert duplicates.
-	if xmlRecord.Model == "core.country.state" || xmlRecord.Model == "core.city" {
-		criteria := map[string]interface{}{"name": fieldValues["name"]}
-		if cid, ok := fieldValues["country_id"]; ok && cid != nil {
-			criteria["country_id"] = cid
-		}
-		if xmlRecord.Model == "core.city" {
-			if sid, ok := fieldValues["state_id"]; ok && sid != nil {
-				criteria["state_id"] = sid
+	// Match existing by natural keys when Upsert cannot use a UNIQUE column.
+	if xmlRecord.Model == "core.country.state" || xmlRecord.Model == "core.city" ||
+		xmlRecord.Model == "account.tax" || xmlRecord.Model == "account.payment.term" ||
+		xmlRecord.Model == "account.move" || xmlRecord.Model == "core.partner" ||
+		xmlRecord.Model == "account.journal" || xmlRecord.Model == "account.move.line" {
+		criteria := map[string]interface{}{}
+		switch xmlRecord.Model {
+		case "core.country.state", "core.city":
+			criteria["name"] = fieldValues["name"]
+			if cid, ok := fieldValues["country_id"]; ok && cid != nil {
+				criteria["country_id"] = cid
+			}
+			if xmlRecord.Model == "core.city" {
+				if sid, ok := fieldValues["state_id"]; ok && sid != nil {
+					criteria["state_id"] = sid
+				}
+			}
+		case "account.tax", "account.payment.term", "core.partner", "account.move":
+			criteria["name"] = fieldValues["name"]
+		case "account.journal":
+			criteria["code"] = fieldValues["code"]
+		case "account.move.line":
+			criteria["name"] = fieldValues["name"]
+			if mid, ok := fieldValues["move_id"]; ok && mid != nil {
+				criteria["move_id"] = mid
 			}
 		}
 		if existing, err := orm.SearchOne(ctx, xmlRecord.Model, criteria); err == nil {
@@ -163,6 +179,13 @@ func ConvertRecordScalar(ctx context.Context, moduleName, model, column, rawValu
 			return boolValue
 		}
 		return strings.EqualFold(trimmedValue, "true") || trimmedValue == "1"
+	}
+	// Numeric / integer literals from eval="…"
+	if n, err := strconv.ParseInt(trimmedValue, 10, 64); err == nil && !strings.Contains(trimmedValue, ".") {
+		return n
+	}
+	if f, err := strconv.ParseFloat(trimmedValue, 64); err == nil {
+		return f
 	}
 	return trimmedValue
 }

--- a/core/orm/object_action.go
+++ b/core/orm/object_action.go
@@ -1,0 +1,52 @@
+package orm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// ObjectActionFunc handles a named object button (type="object") on a record.
+// Return a non-empty Redirect to send the browser there after success.
+type ObjectActionFunc func(ctx context.Context, model string, id int, vals map[string]string) (redirect string, err error)
+
+var (
+	objectActionMu sync.RWMutex
+	objectActions  = map[string]map[string]ObjectActionFunc{} // model → method → fn
+)
+
+// RegisterObjectAction registers a handler for model + method (e.g. account.move / action_post).
+// Later registration for the same pair replaces the earlier handler.
+func RegisterObjectAction(model, method string, fn ObjectActionFunc) {
+	model = strings.TrimSpace(model)
+	method = strings.TrimSpace(method)
+	if model == "" || method == "" || fn == nil {
+		return
+	}
+	objectActionMu.Lock()
+	defer objectActionMu.Unlock()
+	if objectActions[model] == nil {
+		objectActions[model] = map[string]ObjectActionFunc{}
+	}
+	objectActions[model][method] = fn
+}
+
+// RunObjectAction invokes a registered object action.
+func RunObjectAction(ctx context.Context, model string, id int, method string, vals map[string]string) (string, error) {
+	model = strings.TrimSpace(model)
+	method = strings.TrimSpace(method)
+	if model == "" || method == "" {
+		return "", fmt.Errorf("model and method are required")
+	}
+	objectActionMu.RLock()
+	var fn ObjectActionFunc
+	if byMethod := objectActions[model]; byMethod != nil {
+		fn = byMethod[method]
+	}
+	objectActionMu.RUnlock()
+	if fn == nil {
+		return "", fmt.Errorf("unknown object action %s.%s", model, method)
+	}
+	return fn(ctx, model, id, vals)
+}

--- a/core/server/api/dispatch.go
+++ b/core/server/api/dispatch.go
@@ -21,7 +21,7 @@ var PublicMethods = map[string]bool{
 }
 
 // rpcRequest is the JSON body for POST /api/rpc.
-// If model is empty and params is set, params is unmarshalled again (Odoo-style wrapper).
+// If model is empty and params is set, params is unmarshalled again (JSON-RPC wrapper).
 type rpcRequest struct {
 	Model  string          `json:"model"`
 	Method string          `json:"method"`

--- a/core/server/router/registry.go
+++ b/core/server/router/registry.go
@@ -16,7 +16,6 @@ const (
 	AuthAPIKey  AuthMode = "apikey" // session or API key (uid > 0)
 )
 
-// Route is one registered HTTP endpoint.
 type Route struct {
 	Method  string
 	Path    string

--- a/core/server/web/auth.go
+++ b/core/server/web/auth.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"sumeru/core/sdk/platformmsg"
 	"sumeru/core/engine/assets"
 	"sumeru/core/engine/render"
 	"sumeru/core/orm"
+	"sumeru/core/sdk/platformmsg"
 	"sumeru/core/server/config"
 
 	"golang.org/x/crypto/bcrypt"
@@ -165,8 +165,7 @@ func LogoutGet(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/web/login", http.StatusFound)
 }
 
-// ActionResetPassword is a stub for the "Send reset instructions" button on the user form.
-// WIP: email delivery is not yet wired; this handler logs the attempt and redirects.
+// TODO: send reset email
 func ActionResetPassword(w http.ResponseWriter, r *http.Request) {
 	if !requireLogin(w, r) {
 		return
@@ -180,7 +179,6 @@ func ActionResetPassword(w http.ResponseWriter, r *http.Request) {
 	userID := strings.TrimSpace(r.PostFormValue("id"))
 	login := strings.TrimSpace(r.PostFormValue("login"))
 	WebLogf(r.Context(), "/web/action/reset_password", "requested for user id=%s login=%q (email not yet wired)", userID, login)
-	// Redirect back with a flash-style query param so the UI can surface it.
 	next := SafeWebNext(r.PostFormValue("next"), "/web/home")
 	http.Redirect(w, r, next+"&msg=reset_requested", http.StatusSeeOther)
 }

--- a/core/server/web/object_action.go
+++ b/core/server/web/object_action.go
@@ -1,0 +1,50 @@
+package web
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"sumeru/core/orm"
+)
+
+// ActionObjectHandler POST /web/action/object — runs a registered object button handler.
+// Form fields: model, id, method, next (optional redirect fallback).
+func ActionObjectHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	model := strings.TrimSpace(r.FormValue("model"))
+	method := strings.TrimSpace(r.FormValue("method"))
+	idStr := strings.TrimSpace(r.FormValue("id"))
+	next := strings.TrimSpace(r.FormValue("next"))
+	id, _ := strconv.Atoi(idStr)
+	if model == "" || method == "" || id <= 0 {
+		http.Error(w, "model, id, and method are required", http.StatusBadRequest)
+		return
+	}
+	vals := map[string]string{}
+	for k, vs := range r.Form {
+		if len(vs) > 0 {
+			vals[k] = vs[0]
+		}
+	}
+	ctx := r.Context()
+	redirect, err := orm.RunObjectAction(ctx, model, id, method, vals)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if redirect == "" {
+		redirect = next
+	}
+	if redirect == "" {
+		redirect = "/web"
+	}
+	http.Redirect(w, r, redirect, http.StatusSeeOther)
+}

--- a/core/server/web/record_delete.go
+++ b/core/server/web/record_delete.go
@@ -7,8 +7,6 @@ import (
 	"sumeru/core/orm"
 )
 
-// RecordDeleteHandler handles DELETE /web/record/save (via POST with _method=DELETE or similar, but we'll just use POST with ?id=...)
-// Actually, let's just make it a dedicated route /web/record/delete
 func RecordDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	if !requireLogin(w, r) {
 		return
@@ -36,7 +34,6 @@ func RecordDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Redirect back to list view
 	actionID := r.URL.Query().Get("action")
 	menuID := r.URL.Query().Get("menu_id")
 	redirectURL := fmt.Sprintf("/web?action=%s&menu_id=%s", actionID, menuID)

--- a/core/server/web/routes_table.go
+++ b/core/server/web/routes_table.go
@@ -40,6 +40,7 @@ func RegisterAppRoutes(mux *http.ServeMux) {
 	router.Register(http.MethodGet, "/web/rel/search", router.AuthSession, RelSearchHandler)
 	router.Register(http.MethodPost, "/web/action/reset_password", router.AuthSession, ActionResetPassword)
 	router.Register(http.MethodPost, "/web/action/create_api_key", router.AuthSession, ActionCreateAPIKey)
+	router.Register(http.MethodPost, "/web/action/object", router.AuthSession, ActionObjectHandler)
 	router.Register(http.MethodPost, "/web/chatter/post", router.AuthSession, ChatterPostHandler)
 	router.Register(http.MethodGet, "/web/settings", router.AuthSession, SettingsHubHandler)
 	router.Register(http.MethodGet, "/web/settings/app-logs", router.AuthSession, AppLogsHandler)

--- a/core/server/web/settings_app_logs.go
+++ b/core/server/web/settings_app_logs.go
@@ -76,7 +76,6 @@ func AppLogsHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(html))
 }
 
-// ModuleEvent is one row for the app logs table template.
 type ModuleEvent struct {
 	CreatedAt string
 	Module    string

--- a/core/server/web/settings_hub.go
+++ b/core/server/web/settings_hub.go
@@ -16,7 +16,6 @@ import (
 	"sumeru/core/server/config"
 )
 
-// settingsHubLink is one entry under a settings section.
 type settingsHubLink struct {
 	Name string
 	Href string

--- a/core/server/web/web_request_helpers.go
+++ b/core/server/web/web_request_helpers.go
@@ -9,7 +9,6 @@ import (
 	"sumeru/core/applog"
 )
 
-// WebLogf writes a structured web log line with enforced fields from applog.L(ctx) (user_id, log_ts, log_tz).
 func WebLogf(ctx context.Context, route, format string, args ...interface{}) {
 	route = strings.TrimSpace(route)
 	if route == "" {
@@ -19,7 +18,6 @@ func WebLogf(ctx context.Context, route, format string, args ...interface{}) {
 	applog.L(ctx).Infow("web", "route", route, "msg", msg)
 }
 
-// SafePathNext returns next if it is a same-site relative path (starts with /, not // open-redirect).
 func SafePathNext(raw, fallback string) string {
 	s := strings.TrimSpace(raw)
 	if s == "" || !strings.HasPrefix(s, "/") || strings.HasPrefix(s, "//") {
@@ -28,7 +26,6 @@ func SafePathNext(raw, fallback string) string {
 	return s
 }
 
-// SafeWebNext returns next if it is under /web (and not an open-redirect via //).
 func SafeWebNext(raw, fallback string) string {
 	s := strings.TrimSpace(raw)
 	if s == "" || !strings.HasPrefix(s, "/web") || strings.HasPrefix(s, "//") {
@@ -37,7 +34,6 @@ func SafeWebNext(raw, fallback string) string {
 	return s
 }
 
-// RequirePOST writes 405 unless r.Method is POST.
 func RequirePOST(w http.ResponseWriter, r *http.Request) bool {
 	if r.Method == http.MethodPost {
 		return true
@@ -46,7 +42,6 @@ func RequirePOST(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
-// ParsePostForm parses the body as application/x-www-form-urlencoded; on error writes 400 and returns false.
 func ParsePostForm(w http.ResponseWriter, r *http.Request) bool {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "Invalid form", http.StatusBadRequest)

--- a/core/server/web/workspace.go
+++ b/core/server/web/workspace.go
@@ -74,12 +74,10 @@ func WebHandler(w http.ResponseWriter, r *http.Request) {
 		modes = []string{"tree"}
 	}
 
-	// Optional ?view_type=... (explicit tab / layout) is applied before the default mode list.
 	if vt := strings.TrimSpace(r.URL.Query().Get("view_type")); vt != "" {
 		modes = append([]string{normalizeViewMode(vt)}, modes...)
 	}
 
-	// Opening a specific record should use the form view; prepend after view_type so ?id=… always wins over ?view_type=tree|kanban.
 	if idStr := strings.TrimSpace(r.URL.Query().Get("id")); idStr != "" {
 		if _, err := strconv.Atoi(idStr); err == nil {
 			modes = append([]string{"form"}, modes...)

--- a/core/server/web/workspace_home_dashboard.go
+++ b/core/server/web/workspace_home_dashboard.go
@@ -17,7 +17,6 @@ import (
 	"sumeru/core/server/config"
 )
 
-// dashAppTile is one installed application module on the Home dashboard.
 type dashAppTile struct {
 	Name         string
 	DisplayName  string


### PR DESCRIPTION
## Summary

Merges `dev` into `main` with platform improvements, core contacts/geo work, form UI fixes, and documentation updates.

### Platform and data
- Add `core.country`, `core.country.state`, and `core.city` models with seed data and geo views
- Move **Contacts** into the core tree (`addons/contacts/`) with partner form, tree, kanban, menus, and security
- Harden XML record sync with natural-key upserts for account/geo seed data
- Split monolithic ORM security definitions into per-model files (`sys_access`, `sys_field`, `sys_rule`, etc.)

### Web UI and rendering
- Add object-action platform: `POST /web/action/object` and wired header/footer `type="object"` form buttons
- Improve form widgets: boolean selects, many2one search/select (`many2one-select.js`), and rel_search filtering
- Fix kanban card layout (image containment, column sizing) and form sheet overflow
- Gate left avatar split layout on models with an `image` field; constrain group/grid width to match notebook
- Workspace CSS updates for structured views (tree/kanban/form scroll regions)

### Code quality
- Trim comment noise across render, parser, web, and base models
- Replace WIP-style notes with short `TODO:` markers where stubs remain
- Remove outdated developer docs under `docs/developer/`

### Documentation
- Add prominent pre-alpha warning to README (no production use, not for sale, evaluation only)
- Refresh README structure and remove em-dashes

## Commits (11)

- `eaa4112` Add geo models and contact address dropdowns; move contacts into core
- `6800e05` Add object-action platform for form buttons and harden XML seed sync
- `bc5ca73` Remove redundant struct comments from base models
- `616efd8` Clean up web comments; use TODO for unfinished stubs
- `34a40d1` Trim comment noise in render and parser packages
- `d327fbf` Drop leftover render helper comment found in verification pass
- `4f73c3a` fix(render): gate form avatar split layout on image field
- `8d78576` fix(css): keep form sheet groups within the form card
- `bb189f6` Contact form view formatting
- `768f8cd` README updated (pre-alpha warning)

## Test plan

- [ ] Pull `dev`, run from `sumeru_custom_addons`: `make generate && make run`
- [ ] Upgrade core modules: `go run . -- -c sumeru.conf -u base,contacts --stop-after-init`
- [ ] **Contacts:** open partner form; confirm title, Contact/Address groups, and notebook stay inside the sheet; kanban cards render correctly
- [ ] **Geo:** on partner form, verify country → state → city cascade via many2one widgets
- [ ] **Account move form** (via sumeru_addons): confirm no empty left avatar rail; sheet layout is contained
- [ ] **Object buttons:** on a form with header `type="object"` buttons, confirm actions POST and redirect correctly
- [ ] **Kanban:** open contacts kanban; images stay inside cards; ~6 cards per row on wide screens
- [ ] Run tests: `cd sumeru && go test ./...`
- [ ] Confirm README pre-alpha CAUTION block renders on GitHub

## Upgrade notes

After merge, workspaces should run:

```bash
cd sumeru_custom_addons
make generate
go run . -- -c sumeru.conf -u base,contacts --stop-after-init
make run