### PR TITLE
Release: gap-plan platform, RPC scale path, and pre-alpha kernel hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build css run generate bp check-sql check-logs db-check i18n-export
+.PHONY: help build css run generate bp check-sql check-logs db-check i18n-export i18n-import migrate module shell test-db test-integration
 
 # Extra flags for `make run`, e.g. `make run EXTRA_RUN_FLAGS='-p 9090 -d sumeru_staging'`
 EXTRA_RUN_FLAGS ?=
@@ -36,6 +36,25 @@ db-check:
 i18n-export:
 	go run ./cmd/sumeru-i18n-export -- -c sumeru.conf -o translations.csv
 
+i18n-import:
+	go run ./cmd/sumeru-i18n-import -- -c sumeru.conf -i translations.csv
+
+migrate:
+	go run ./cmd/sumeru-migrate -- -c sumeru.conf
+
+module:
+	go run ./cmd/sumeru-module -- -c sumeru.conf $(ARGS)
+
+shell:
+	go run ./cmd/sumeru-shell -- -c sumeru.conf
+
+test-db:
+	docker compose -f docker-compose.test.yml up -d --wait
+
+test-integration: test-db
+	SUMERU_TEST_DSN='host=localhost port=5433 user=postgres password=postgres dbname=sumeru_test sslmode=disable' \
+		go test -tags=integration ./test/integration/... -count=1
+
 help:
 	@echo "Sumeru Makefile targets:"
 	@echo "  make generate - go generate ./cmd/sumeru (refresh cmd/sumeru/zimports.go from sumeru.conf.example; copy to sumeru.conf for make run)"
@@ -47,5 +66,11 @@ help:
 	@echo "  make check-logs - forbid stdlib log and operational fmt.Printf in server paths"
 	@echo "  make db-check  - validate sumeru.conf and PostgreSQL connectivity"
 	@echo "  make i18n-export - export sys.translation rows to translations.csv"
+	@echo "  make i18n-import - import translations.csv into sys.translation"
+	@echo "  make migrate     - run pending module SQL migrations"
+	@echo "  make module      - module CLI (ARGS='list' | 'depends-tree' | 'install sales' | ...)"
+	@echo "  make shell       - interactive ORM REPL (sumeru-shell)"
+	@echo "  make test-db     - start PostgreSQL via docker-compose.test.yml"
+	@echo "  make test-integration - run go test -tags=integration against test DB"
 	@echo "  make help    - this message"
 	@echo "See README.md for CLI flags (-d, -i, -u, -p/--http-port, --stop-after-init) and sumeru.sh."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build css run generate bp check-sql check-logs
+.PHONY: help build css run generate bp check-sql check-logs db-check i18n-export
 
 # Extra flags for `make run`, e.g. `make run EXTRA_RUN_FLAGS='-p 9090 -d sumeru_staging'`
 EXTRA_RUN_FLAGS ?=
@@ -30,6 +30,12 @@ bp:
 css:
 	@echo "No CSS build step — edit core/engine/assets/css/*.css"
 
+db-check:
+	go run ./cmd/sumeru-db-check -- -c sumeru.conf
+
+i18n-export:
+	go run ./cmd/sumeru-i18n-export -- -c sumeru.conf -o translations.csv
+
 help:
 	@echo "Sumeru Makefile targets:"
 	@echo "  make generate - go generate ./cmd/sumeru (refresh cmd/sumeru/zimports.go from sumeru.conf.example; copy to sumeru.conf for make run)"
@@ -39,5 +45,7 @@ help:
 	@echo "  make css     - reminder: styles are plain CSS (no compile step)"
 	@echo "  make check-sql - static SQL injection pattern guard"
 	@echo "  make check-logs - forbid stdlib log and operational fmt.Printf in server paths"
+	@echo "  make db-check  - validate sumeru.conf and PostgreSQL connectivity"
+	@echo "  make i18n-export - export sys.translation rows to translations.csv"
 	@echo "  make help    - this message"
 	@echo "See README.md for CLI flags (-d, -i, -u, -p/--http-port, --stop-after-init) and sumeru.sh."

--- a/addons/automation/actions.go
+++ b/addons/automation/actions.go
@@ -1,0 +1,78 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"sumeru/core/applog"
+	"sumeru/core/event"
+	"sumeru/core/orm"
+)
+
+// executeServerAction runs a matching sys.server.action row for an event.
+// Code conventions (declarative, no script engine):
+//   - publish:<event_name>  — publish a follow-up event (payload copied from trigger)
+//   - write:<json_object>   — ORM write on payload model/id
+func executeServerAction(ctx context.Context, row map[string]interface{}, ev event.Event) error {
+	actionModel := strings.TrimSpace(orm.AsString(row["model"]))
+	if actionModel != "" {
+		evModel := strings.TrimSpace(orm.AsString(ev.Payload["model"]))
+		if evModel != "" && actionModel != evModel {
+			return nil
+		}
+	}
+
+	code := strings.TrimSpace(orm.AsString(row["code"]))
+	if code == "" {
+		return nil
+	}
+
+	switch {
+	case strings.HasPrefix(code, "publish:"):
+		name := strings.TrimSpace(strings.TrimPrefix(code, "publish:"))
+		if name == "" {
+			return nil
+		}
+		payload := ev.Payload
+		if payload == nil {
+			payload = map[string]interface{}{}
+		}
+		errs := event.Publish(ctx, event.Event{Name: name, Actor: ev.Actor, Payload: payload})
+		if len(errs) > 0 {
+			return errs[0]
+		}
+		return nil
+
+	case strings.HasPrefix(code, "write:"):
+		raw := strings.TrimSpace(strings.TrimPrefix(code, "write:"))
+		if raw == "" {
+			return nil
+		}
+		var vals map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &vals); err != nil {
+			applog.Warn(ctx, applog.Event{
+				Message:   "server action write JSON invalid",
+				Component: "automation",
+				Operation: "server_action",
+				Status:    "failed",
+				Context:   map[string]interface{}{"action": row["name"]},
+				Err:       err,
+			})
+			return nil
+		}
+		modelName := strings.TrimSpace(orm.AsString(ev.Payload["model"]))
+		resID, ok := orm.CoerceInt64(ev.Payload["id"])
+		if modelName == "" || !ok || resID <= 0 {
+			return nil
+		}
+		bypass := orm.ContextWithBypass(ctx, true)
+		return orm.UpdateRecordByID(bypass, modelName, int(resID), vals)
+
+	default:
+		applog.DebugMsg(ctx, "module", "automation",
+			"server action code not executed (unknown prefix)",
+			map[string]interface{}{"action": row["name"], "code": code})
+	}
+	return nil
+}

--- a/addons/automation/actions_test.go
+++ b/addons/automation/actions_test.go
@@ -1,0 +1,53 @@
+package automation
+
+import (
+	"context"
+	"testing"
+
+	"sumeru/core/event"
+)
+
+func TestExecuteServerActionPublishPrefix(t *testing.T) {
+	ctx := context.Background()
+	var got string
+	event.Subscribe("test.followup", func(_ context.Context, ev event.Event) error {
+		got = ev.Name
+		return nil
+	})
+	defer event.Clear()
+
+	row := map[string]interface{}{
+		"name": "Test Action",
+		"code": "publish:test.followup",
+	}
+	ev := event.Event{Name: "record.created", Payload: map[string]interface{}{"model": "crm.lead", "id": 1}}
+	if err := executeServerAction(ctx, row, ev); err != nil {
+		t.Fatal(err)
+	}
+	if got != "test.followup" {
+		t.Fatalf("expected test.followup, got %q", got)
+	}
+}
+
+func TestExecuteServerActionModelFilter(t *testing.T) {
+	ctx := context.Background()
+	var got string
+	event.Subscribe("test.filtered", func(_ context.Context, ev event.Event) error {
+		got = ev.Name
+		return nil
+	})
+	defer event.Clear()
+
+	row := map[string]interface{}{
+		"name":  "Filtered",
+		"model": "sale.order",
+		"code":  "publish:test.filtered",
+	}
+	ev := event.Event{Name: "record.updated", Payload: map[string]interface{}{"model": "crm.lead", "id": 1}}
+	if err := executeServerAction(ctx, row, ev); err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("expected no publish, got %q", got)
+	}
+}

--- a/addons/automation/init.go
+++ b/addons/automation/init.go
@@ -2,7 +2,6 @@ package automation
 
 import (
 	"context"
-	"fmt"
 
 	_ "sumeru/addons/automation/models"
 	"sumeru/core/applog"
@@ -16,7 +15,6 @@ func init() {
 	event.Subscribe("cron.tick", runServerActionsForEvent)
 }
 
-// TODO: run server actions (log matches for now)
 func runServerActionsForEvent(ctx context.Context, ev event.Event) error {
 	if orm.DB == nil {
 		return nil
@@ -33,9 +31,16 @@ func runServerActionsForEvent(ctx context.Context, ev event.Event) error {
 		return err
 	}
 	for _, row := range rows {
-		applog.DebugMsg(ctx, "module", "automation",
-			fmt.Sprintf("server action %v on event %s", row["name"], ev.Name),
-			map[string]interface{}{"module": "automation", "event": ev.Name})
+		if err := executeServerAction(ctx, row, ev); err != nil {
+			applog.Warn(ctx, applog.Event{
+				Message:   "server action failed",
+				Component: "automation",
+				Operation: "server_action",
+				Status:    "failed",
+				Context:   map[string]interface{}{"event": ev.Name, "action": row["name"]},
+				Err:       err,
+			})
+		}
 	}
 	return nil
 }

--- a/addons/base/migrations/001_translation_unique.sql
+++ b/addons/base/migrations/001_translation_unique.sql
@@ -1,0 +1,3 @@
+-- Unique key for i18n import upserts (lang + source + module).
+CREATE UNIQUE INDEX IF NOT EXISTS sys_translation_lang_src_module_uidx
+  ON sys_translation (lang, src, module);

--- a/addons/base/user_object_actions.go
+++ b/addons/base/user_object_actions.go
@@ -3,8 +3,10 @@ package base
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"sumeru/core/applog"
+	"sumeru/core/mail"
 	"sumeru/core/orm"
 )
 
@@ -38,7 +40,23 @@ func resetPasswordCoreUser(ctx context.Context, model string, id int, vals map[s
 		return "", fmt.Errorf("record not found")
 	}
 	login := orm.AsString(rec["login"])
-	applog.InfoMsg(ctx, "base", "user_action", "Password reset requested (email not yet wired)",
+	to := strings.TrimSpace(orm.AsString(rec["email"]))
+	if to == "" && strings.Contains(login, "@") {
+		to = login
+	}
+	loginURL := strings.TrimSpace(vals["login_url"])
+	if loginURL == "" {
+		loginURL = "/web/login"
+	}
+	if mail.Configured() && to != "" {
+		if err := mail.SendPasswordResetEmail(ctx, to, login, loginURL); err != nil {
+			return "", fmt.Errorf("send reset email: %w", err)
+		}
+		applog.InfoMsg(ctx, "base", "user_action", "Password reset email sent",
+			map[string]interface{}{"user_id": id, "login": login, "to": to})
+		return "", nil
+	}
+	applog.InfoMsg(ctx, "base", "user_action", "Password reset requested (configure smtp_host/smtp_from to send email)",
 		map[string]interface{}{"user_id": id, "login": login})
 	return "", nil
 }

--- a/cmd/sumeru-db-check/main.go
+++ b/cmd/sumeru-db-check/main.go
@@ -1,0 +1,50 @@
+// Command sumeru-db-check validates sumeru.conf and PostgreSQL connectivity.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"sumeru/core/server/config"
+)
+
+func main() {
+	configPath := flag.String("c", "sumeru.conf", "Path to config file (INI)")
+	flag.Parse()
+
+	if err := config.LoadConfig(*configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		os.Exit(1)
+	}
+	if err := config.AbsPaths(); err != nil {
+		fmt.Fprintf(os.Stderr, "paths: %v\n", err)
+		os.Exit(1)
+	}
+
+	c := config.AppConfig
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s connect_timeout=5",
+		c.DbHost, c.DbPort, c.DbUser, c.DbPass, c.DbName, c.DbSslMode)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "db open: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "db ping: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("OK: database %s@%s:%s/%s reachable\n", c.DbUser, c.DbHost, c.DbPort, c.DbName)
+}

--- a/cmd/sumeru-i18n-export/main.go
+++ b/cmd/sumeru-i18n-export/main.go
@@ -1,0 +1,90 @@
+// Command sumeru-i18n-export dumps sys.translation rows to CSV.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"sumeru/core/server/config"
+)
+
+func main() {
+	configPath := flag.String("c", "sumeru.conf", "Path to config file (INI)")
+	outPath := flag.String("o", "translations.csv", "Output CSV path")
+	flag.Parse()
+
+	if err := config.LoadConfig(*configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		os.Exit(1)
+	}
+	c := config.AppConfig
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		c.DbHost, c.DbPort, c.DbUser, c.DbPass, c.DbName, c.DbSslMode)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "db open: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	tableName, err := modelTableName("sys.translation")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "table name: %v\n", err)
+		os.Exit(1)
+	}
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT lang, src, value, module FROM "`+tableName+`" ORDER BY lang, module, src`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "query: %v\n", err)
+		os.Exit(1)
+	}
+	defer rows.Close()
+
+	f, err := os.Create(*outPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create output: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	_ = w.Write([]string{"lang", "src", "value", "module"})
+	count := 0
+	for rows.Next() {
+		var lang, src, value, module string
+		if err := rows.Scan(&lang, &src, &value, &module); err != nil {
+			fmt.Fprintf(os.Stderr, "scan: %v\n", err)
+			os.Exit(1)
+		}
+		_ = w.Write([]string{lang, src, value, module})
+		count++
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		fmt.Fprintf(os.Stderr, "write csv: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Exported %d translation rows to %s\n", count, *outPath)
+}
+
+func modelTableName(model string) (string, error) {
+	// sys.translation -> sys_translation (matches ORM physical naming)
+	name := strings.ReplaceAll(model, ".", "_")
+	if name == "" {
+		return "", fmt.Errorf("empty model")
+	}
+	return name, nil
+}

--- a/cmd/sumeru-i18n-import/main.go
+++ b/cmd/sumeru-i18n-import/main.go
@@ -1,0 +1,100 @@
+// Command sumeru-i18n-import loads translation rows from CSV into sys.translation.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"sumeru/core/server/cliboot"
+)
+
+func main() {
+	configPath := flag.String("c", "sumeru.conf", "Path to config file (INI)")
+	inPath := flag.String("i", "translations.csv", "Input CSV path")
+	flag.Parse()
+
+	if _, err := cliboot.Init(*configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "init: %v\n", err)
+		os.Exit(1)
+	}
+
+	f, err := os.Open(*inPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	records, err := r.ReadAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "csv: %v\n", err)
+		os.Exit(1)
+	}
+	if len(records) < 2 {
+		fmt.Println("No data rows.")
+		return
+	}
+	header := records[0]
+	col := map[string]int{}
+	for i, h := range header {
+		col[strings.ToLower(strings.TrimSpace(h))] = i
+	}
+	for _, req := range []string{"lang", "src", "value", "module"} {
+		if _, ok := col[req]; !ok {
+			fmt.Fprintf(os.Stderr, "missing column %q\n", req)
+			os.Exit(1)
+		}
+	}
+
+	db, err := sql.Open("postgres", cliboot.DSN())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "db: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	tableName, _ := modelTableName("sys.translation")
+	imported := 0
+	for _, row := range records[1:] {
+		if len(row) < len(header) {
+			continue
+		}
+		lang := strings.TrimSpace(row[col["lang"]])
+		src := strings.TrimSpace(row[col["src"]])
+		val := row[col["value"]]
+		mod := strings.TrimSpace(row[col["module"]])
+		if lang == "" || src == "" {
+			continue
+		}
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO "`+tableName+`" (lang, src, value, module)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (lang, src, module) DO UPDATE SET value = EXCLUDED.value`, lang, src, val, mod)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "insert: %v\n", err)
+			os.Exit(1)
+		}
+		imported++
+	}
+	fmt.Printf("Imported %d translation rows from %s\n", imported, *inPath)
+}
+
+func modelTableName(model string) (string, error) {
+	name := strings.ReplaceAll(model, ".", "_")
+	if name == "" {
+		return "", fmt.Errorf("empty model")
+	}
+	return name, nil
+}

--- a/cmd/sumeru-migrate/main.go
+++ b/cmd/sumeru-migrate/main.go
@@ -1,0 +1,37 @@
+// Command sumeru-migrate runs versioned SQL migrations from addon migrations/ folders.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"sumeru/core/module"
+	"sumeru/core/server/cliboot"
+)
+
+func main() {
+	configPath := flag.String("c", "sumeru.conf", "Path to config file (INI)")
+	moduleName := flag.String("module", "all", "Module name or 'all'")
+	flag.Parse()
+
+	ctx, err := cliboot.Init(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "init: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.EqualFold(strings.TrimSpace(*moduleName), "all") {
+		if err := module.RunAllMigrations(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("All migrations applied.")
+		return
+	}
+	if err := module.RunModuleMigrations(ctx, strings.TrimSpace(*moduleName)); err != nil {
+		fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Migrations applied for %s\n", *moduleName)
+}

--- a/cmd/sumeru-module/main.go
+++ b/cmd/sumeru-module/main.go
@@ -1,0 +1,177 @@
+// Command sumeru-module manages addons without starting the HTTP server.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"sumeru/core/module"
+	"sumeru/core/server/cliboot"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	configPath := "sumeru.conf"
+	args := os.Args[1:]
+	if len(args) >= 2 && args[0] == "-c" {
+		configPath = args[1]
+		args = args[2:]
+	}
+	cmd := strings.ToLower(strings.TrimSpace(args[0]))
+	subArgs := args[1:]
+
+	switch cmd {
+	case "list":
+		runList(configPath)
+	case "depends-tree", "depends":
+		if len(subArgs) == 0 {
+			fmt.Fprintln(os.Stderr, "usage: sumeru-module depends-tree MODULE")
+			os.Exit(1)
+		}
+		runDepends(configPath, subArgs[0])
+	case "install":
+		if len(subArgs) == 0 {
+			fmt.Fprintln(os.Stderr, "usage: sumeru-module install mod1,mod2")
+			os.Exit(1)
+		}
+		runInstall(configPath, strings.Join(subArgs, " "))
+	case "update":
+		if len(subArgs) == 0 {
+			fmt.Fprintln(os.Stderr, "usage: sumeru-module update mod|all")
+			os.Exit(1)
+		}
+		runUpdate(configPath, strings.Join(subArgs, " "))
+	case "uninstall":
+		if len(subArgs) == 0 {
+			fmt.Fprintln(os.Stderr, "usage: sumeru-module uninstall MODULE")
+			os.Exit(1)
+		}
+		runUninstall(configPath, subArgs[0])
+	case "migrate":
+		runMigrate(configPath, subArgs)
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage: sumeru-module [-c sumeru.conf] COMMAND
+
+Commands:
+  list                         List discovered modules and DB state
+  depends-tree MODULE          Print dependency tree
+  install mod1,mod2            Install modules
+  update mod|all               Update module metadata from disk
+  uninstall MODULE             Uninstall module
+  migrate [mod|all]            Run SQL migrations from addons/*/migrations/
+`)
+}
+
+func runList(configPath string) {
+	ctx, err := cliboot.InitOptionalDB(configPath, true)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	infos, err := module.ListModuleInfo(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	for _, m := range infos {
+		app := ""
+		if m.Application {
+			app = " app"
+		}
+		fmt.Printf("%-20s %-12s v%s%s\n", m.Name, m.State, m.Version, app)
+	}
+}
+
+func runDepends(configPath, mod string) {
+	_, err := cliboot.InitOptionalDB(configPath, false)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	out, err := module.DependsTree(mod)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Print(out)
+}
+
+func runInstall(configPath, csv string) {
+	ctx, err := cliboot.Init(configPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	_ = ctx
+	if err := module.RunModuleCLI(csv, ""); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("Install complete.")
+}
+
+func runUpdate(configPath, csv string) {
+	ctx, err := cliboot.Init(configPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	_ = ctx
+	if err := module.RunModuleCLI("", csv); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("Update complete.")
+}
+
+func runUninstall(configPath, mod string) {
+	ctx, err := cliboot.Init(configPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := module.UninstallModuleByName(ctx, strings.TrimSpace(mod)); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Uninstalled %s\n", mod)
+}
+
+func runMigrate(configPath string, args []string) {
+	ctx, err := cliboot.Init(configPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	target := "all"
+	if len(args) > 0 {
+		target = strings.TrimSpace(args[0])
+	}
+	if strings.EqualFold(target, "all") {
+		if err := module.RunAllMigrations(ctx); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println("All migrations applied.")
+		return
+	}
+	if err := module.RunModuleMigrations(ctx, target); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Migrations applied for %s\n", target)
+}
+
+// satisfy flag import when extended
+var _ = flag.CommandLine

--- a/cmd/sumeru-shell/main.go
+++ b/cmd/sumeru-shell/main.go
@@ -1,0 +1,177 @@
+// Command sumeru-shell is an interactive ORM REPL for developers.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"sumeru/core/orm"
+	"sumeru/core/server/cliboot"
+)
+
+func main() {
+	configPath := flag.String("c", "sumeru.conf", "Path to config file (INI)")
+	uidFlag := flag.Int("uid", 1, "Security uid for ORM calls")
+	flag.Parse()
+
+	ctx, err := cliboot.Init(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "init: %v\n", err)
+		os.Exit(1)
+	}
+	ctx = cliboot.ContextWithUID(ctx, *uidFlag)
+
+	fmt.Println("Sumeru shell — commands: search, read, create, write, domain, models, quit")
+	sc := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("sumeru> ")
+		if !sc.Scan() {
+			break
+		}
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		parts := splitFields(line)
+		cmd := strings.ToLower(parts[0])
+		switch cmd {
+		case "quit", "exit", "q":
+			return
+		case "help", "?":
+			printHelp()
+		case "models":
+			for name := range orm.Registry {
+				fmt.Println(name)
+			}
+		case "search":
+			if len(parts) < 2 {
+				fmt.Println("usage: search MODEL [limit]")
+				continue
+			}
+			limit := 10
+			if len(parts) >= 3 {
+				limit, _ = strconv.Atoi(parts[2])
+			}
+			rows, err := orm.SearchLimit(ctx, parts[1], nil, limit)
+			if err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			printJSON(rows)
+		case "read":
+			if len(parts) < 3 {
+				fmt.Println("usage: read MODEL ID")
+				continue
+			}
+			id, _ := strconv.Atoi(parts[2])
+			row, err := orm.SearchOne(ctx, parts[1], map[string]interface{}{"id": id})
+			if err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			printJSON(row)
+		case "create":
+			if len(parts) < 3 {
+				fmt.Println(`usage: create MODEL {"field":"value"}`)
+				continue
+			}
+			var vals map[string]interface{}
+			if err := json.Unmarshal([]byte(strings.Join(parts[2:], " ")), &vals); err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			inst, ok := orm.Registry[parts[1]]
+			if !ok || inst == nil {
+				fmt.Println("error: unknown model")
+				continue
+			}
+			id, err := orm.Create(ctx, inst, vals)
+			if err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			fmt.Println("id:", id)
+		case "write":
+			if len(parts) < 4 {
+				fmt.Println(`usage: write MODEL ID {"field":"value"}`)
+				continue
+			}
+			id, _ := strconv.Atoi(parts[2])
+			var vals map[string]interface{}
+			if err := json.Unmarshal([]byte(strings.Join(parts[3:], " ")), &vals); err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			if err := orm.UpdateRecordByID(ctx, parts[1], id, vals); err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			fmt.Println("ok")
+		case "domain":
+			if len(parts) < 3 {
+				fmt.Println(`usage: domain MODEL [[ "field","=","x" ]]`)
+				continue
+			}
+			raw := strings.Join(parts[2:], " ")
+			dom, err := orm.ParseDomainJSON(raw)
+			if err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			where, args, err := orm.BuildWhereWithRecordRules(ctx, orm.SecurityUID(ctx), parts[1], "read", dom)
+			if err != nil {
+				fmt.Println("error:", err)
+				continue
+			}
+			fmt.Println("WHERE:", where)
+			fmt.Println("ARGS:", args)
+		default:
+			fmt.Println("unknown command; type help")
+		}
+	}
+}
+
+func printHelp() {
+	fmt.Println(`Commands:
+  models                          List registered models
+  search MODEL [limit]              Search records
+  read MODEL ID                   Read one record
+  create MODEL {json}             Create record
+  write MODEL ID {json}           Update record
+  domain MODEL [domain-json]      Preview SQL WHERE for domain
+  quit                            Exit`)
+}
+
+func splitFields(s string) []string {
+	var out []string
+	var cur strings.Builder
+	inQuote := false
+	for _, r := range s {
+		switch {
+		case r == '"':
+			inQuote = !inQuote
+			cur.WriteRune(r)
+		case r == ' ' && !inQuote:
+			if cur.Len() > 0 {
+				out = append(out, cur.String())
+				cur.Reset()
+			}
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+func printJSON(v interface{}) {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	fmt.Println(string(b))
+}

--- a/core/engine/assets/css/sumeru-views.css
+++ b/core/engine/assets/css/sumeru-views.css
@@ -1130,6 +1130,52 @@
   color: var(--sum-muted);
 }
 
+.sum-pivot-view {
+  padding: 0 0 1.5rem;
+}
+
+.sum-pivot-title {
+  margin: 0 0 1rem;
+  font-size: var(--sum-font-size-xl);
+  font-weight: var(--sum-font-weight-semibold);
+}
+
+.sum-pivot-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--sum-line);
+  border-radius: var(--sum-radius);
+  background: var(--sum-surface);
+}
+
+.sum-pivot-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--sum-font-size-sm);
+}
+
+.sum-pivot-table th,
+.sum-pivot-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--sum-line);
+  text-align: right;
+}
+
+.sum-pivot-table th:first-child,
+.sum-pivot-table td:first-child {
+  text-align: left;
+}
+
+.sum-pivot-table thead th {
+  background: var(--sum-surface-alt, var(--sum-surface));
+  font-weight: var(--sum-font-weight-semibold);
+}
+
+.sum-pivot-measure {
+  margin: 0.75rem 0 0;
+  font-size: var(--sum-font-size-sm);
+  color: var(--sum-muted);
+}
+
 .sum-security-card {
   border: 1px solid var(--sum-line);
   border-radius: var(--sum-radius-sm);

--- a/core/engine/parser/view_xml.go
+++ b/core/engine/parser/view_xml.go
@@ -138,6 +138,7 @@ type Field struct {
 	Placeholder string `xml:"placeholder,attr"`
 	Options     string `xml:"options,attr"`
 	Groups      string `xml:"groups,attr"`
+	PivotType   string `xml:"type,attr"` // row | col | measure (pivot views only)
 }
 
 type Group struct {

--- a/core/engine/render/list_render.go
+++ b/core/engine/render/list_render.go
@@ -12,7 +12,7 @@ import (
 	"sumeru/core/report"
 )
 
-func RenderList(ctx context.Context, view *parser.View, rows []map[string]interface{}, actionID int, menuID string, csrfToken string) string {
+func RenderList(ctx context.Context, view *parser.View, rows []map[string]interface{}, actionID int, menuID string, csrfToken string, searchQuery string, _ string) string {
 	if rows == nil {
 		rows = []map[string]interface{}{}
 	}
@@ -38,9 +38,18 @@ func RenderList(ctx context.Context, view *parser.View, rows []map[string]interf
 	}
 	sb.WriteString(`</div>`)
 	sb.WriteString(`<div class="sum-list-search-wrap" role="search">`)
+	sb.WriteString(`<form method="GET" action="/web" class="sum-list-search-form">`)
+	if actionID > 0 {
+		sb.WriteString(`<input type="hidden" name="action" value="` + template.HTMLEscapeString(strconv.Itoa(actionID)) + `" />`)
+	}
+	if menuTrim := strings.TrimSpace(menuID); menuTrim != "" {
+		sb.WriteString(`<input type="hidden" name="menu_id" value="` + template.HTMLEscapeString(menuTrim) + `" />`)
+	}
+	sb.WriteString(`<input type="hidden" name="view_type" value="list" />`)
 	sb.WriteString(`<span class="sum-list-search-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg></span>`)
-	sb.WriteString(`<input type="search" class="sum-list-search" placeholder="Search…" disabled aria-disabled="true" />`)
+	sb.WriteString(`<input type="search" name="q" class="sum-list-search" placeholder="Search…" value="` + template.HTMLEscapeString(strings.TrimSpace(searchQuery)) + `" />`)
 	sb.WriteString(`<span class="sum-list-search-caret" aria-hidden="true"></span>`)
+	sb.WriteString(`</form>`)
 	sb.WriteString(`</div>`)
 	sb.WriteString(`</div>`)
 

--- a/core/engine/render/pivot_render.go
+++ b/core/engine/render/pivot_render.go
@@ -2,18 +2,164 @@ package render
 
 import (
 	"context"
+	"fmt"
+	"html/template"
+	"sort"
+	"strconv"
 	"strings"
 
 	"sumeru/core/engine/parser"
+	"sumeru/core/orm"
 )
 
-// TODO: pivot view
-func RenderPivot(_ context.Context, _ *parser.View) string {
+// BuildPivotData aggregates list rows for a pivot view definition.
+func BuildPivotData(view *parser.View, rows []map[string]interface{}) *PivotData {
+	if view == nil || len(view.Field) == 0 {
+		return nil
+	}
+	var rowFields, colFields, measureFields []parser.Field
+	for _, f := range view.Field {
+		switch strings.ToLower(strings.TrimSpace(f.PivotType)) {
+		case "row":
+			rowFields = append(rowFields, f)
+		case "col", "column":
+			colFields = append(colFields, f)
+		case "measure":
+			measureFields = append(measureFields, f)
+		}
+	}
+	if len(measureFields) == 0 {
+		return nil
+	}
+	measure := measureFields[0]
+	measureLabel := FieldDisplayLabel(measure)
+
+	values := map[string]map[string]float64{}
+	rowSet := map[string]struct{}{}
+	colSet := map[string]struct{}{}
+
+	for _, row := range rows {
+		rowKey := pivotKey(row, rowFields)
+		colKey := pivotKey(row, colFields)
+		if colKey == "" {
+			colKey = "Total"
+		}
+		rowSet[rowKey] = struct{}{}
+		colSet[colKey] = struct{}{}
+		if values[rowKey] == nil {
+			values[rowKey] = map[string]float64{}
+		}
+		values[rowKey][colKey] += pivotMeasure(row, measure.Name)
+	}
+
+	out := &PivotData{
+		RowLabels:    pivotSortedKeys(rowSet),
+		ColLabels:    pivotSortedKeys(colSet),
+		Values:       values,
+		MeasureLabel: measureLabel,
+	}
+	if len(out.RowLabels) == 0 {
+		out.RowLabels = []string{"Total"}
+	}
+	return out
+}
+
+func pivotKey(row map[string]interface{}, fields []parser.Field) string {
+	if len(fields) == 0 {
+		return "Total"
+	}
+	parts := make([]string, 0, len(fields))
+	for _, f := range fields {
+		parts = append(parts, pivotCellLabel(row, f.Name))
+	}
+	return strings.Join(parts, " / ")
+}
+
+func pivotCellLabel(row map[string]interface{}, fieldName string) string {
+	if v, ok := row[fieldName+"_name"]; ok && orm.AsString(v) != "" {
+		return orm.AsString(v)
+	}
+	v := row[fieldName]
+	if v == nil {
+		return "—"
+	}
+	return strings.TrimSpace(fmt.Sprint(v))
+}
+
+func pivotMeasure(row map[string]interface{}, fieldName string) float64 {
+	v := row[fieldName]
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case string:
+		f, _ := strconv.ParseFloat(strings.TrimSpace(n), 64)
+		return f
+	default:
+		f, _ := strconv.ParseFloat(strings.TrimSpace(fmt.Sprint(v)), 64)
+		return f
+	}
+}
+
+func pivotSortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// RenderPivot builds HTML for a pivot workspace view.
+func RenderPivot(_ context.Context, view *parser.View, data *PivotData) string {
+	if data == nil || len(data.ColLabels) == 0 {
+		return pivotPlaceholder()
+	}
+	var sb strings.Builder
+	title := HumanViewBreadcrumb(view.Model, "pivot")
+	sb.WriteString(`<div class="sum-pivot-view">`)
+	sb.WriteString(`<h1 class="sum-pivot-title">` + template.HTMLEscapeString(title) + `</h1>`)
+	sb.WriteString(`<div class="sum-pivot-table-wrap"><table class="sum-pivot-table">`)
+	sb.WriteString(`<thead><tr><th></th>`)
+	for _, col := range data.ColLabels {
+		sb.WriteString(`<th>` + template.HTMLEscapeString(col) + `</th>`)
+	}
+	sb.WriteString(`</tr></thead><tbody>`)
+	for _, rowLabel := range data.RowLabels {
+		sb.WriteString(`<tr><th scope="row">` + template.HTMLEscapeString(rowLabel) + `</th>`)
+		rowVals := data.Values[rowLabel]
+		for _, col := range data.ColLabels {
+			val := rowVals[col]
+			sb.WriteString(`<td>` + template.HTMLEscapeString(formatPivotNumber(val)) + `</td>`)
+		}
+		sb.WriteString(`</tr>`)
+	}
+	sb.WriteString(`</tbody></table></div>`)
+	if data.MeasureLabel != "" {
+		sb.WriteString(`<p class="sum-pivot-measure">Measure: ` + template.HTMLEscapeString(data.MeasureLabel) + `</p>`)
+	}
+	sb.WriteString(`</div>`)
+	return sb.String()
+}
+
+func formatPivotNumber(v float64) string {
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d", int64(v))
+	}
+	return fmt.Sprintf("%.2f", v)
+}
+
+func pivotPlaceholder() string {
 	var sb strings.Builder
 	sb.WriteString(`<div class="sum-pivot-placeholder">`)
 	sb.WriteString(`<svg class="sum-pivot-placeholder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>`)
 	sb.WriteString(`<h3 class="sum-pivot-placeholder-title">Pivot view</h3>`)
-	sb.WriteString(`<p class="sum-pivot-placeholder-text">Analytics and reporting will appear here.</p>`)
+	sb.WriteString(`<p class="sum-pivot-placeholder-text">Add pivot fields with type="row", type="col", and type="measure" in the view arch.</p>`)
 	sb.WriteString(`</div>`)
 	return sb.String()
 }

--- a/core/engine/render/render_types.go
+++ b/core/engine/render/render_types.go
@@ -158,6 +158,10 @@ type ViewRecordData struct {
 
 	// Pivot aggregation (view type pivot).
 	Pivot *PivotData
+
+	// List view quick search (GET q=).
+	ListSearchQuery string
+	ListSearchURL   string
 }
 
 // PivotData holds aggregated pivot table cells for HTML rendering.

--- a/core/engine/render/render_types.go
+++ b/core/engine/render/render_types.go
@@ -155,4 +155,15 @@ type ViewRecordData struct {
 	FormSaveAction string // POST URL; default "/web/record/save"
 	CSRFToken      string // per-session CSRF hidden field value
 	FlashMessages  []FlashMessage
+
+	// Pivot aggregation (view type pivot).
+	Pivot *PivotData
+}
+
+// PivotData holds aggregated pivot table cells for HTML rendering.
+type PivotData struct {
+	RowLabels    []string
+	ColLabels    []string
+	Values       map[string]map[string]float64 // rowKey -> colKey -> sum
+	MeasureLabel string
 }

--- a/core/engine/render/view_render.go
+++ b/core/engine/render/view_render.go
@@ -22,7 +22,7 @@ func RenderView(ctx context.Context, view *parser.View, activeMenuID, templatesD
 	case "form":
 		content = RenderForm(ctx, view, recData)
 	case "list":
-		content = RenderList(ctx, view, recData.ListRows, recData.ActionID, activeMenuID, recData.CSRFToken)
+		content = RenderList(ctx, view, recData.ListRows, recData.ActionID, activeMenuID, recData.CSRFToken, recData.ListSearchQuery, recData.ListSearchURL)
 	case "kanban":
 		content = RenderKanban(ctx, view, recData, recData.ActionID, activeMenuID)
 	case "pivot":

--- a/core/engine/render/view_render.go
+++ b/core/engine/render/view_render.go
@@ -26,7 +26,7 @@ func RenderView(ctx context.Context, view *parser.View, activeMenuID, templatesD
 	case "kanban":
 		content = RenderKanban(ctx, view, recData, recData.ActionID, activeMenuID)
 	case "pivot":
-		content = RenderPivot(ctx, view)
+		content = RenderPivot(ctx, view, recData.Pivot)
 	default:
 		content = RenderForm(ctx, view, recData)
 	}

--- a/core/mail/smtp.go
+++ b/core/mail/smtp.go
@@ -1,0 +1,127 @@
+// Package mail sends transactional email via SMTP when configured in sumeru.conf.
+package mail
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+
+	"sumeru/core/applog"
+)
+
+// SMTPConfig holds outbound mail settings from INI.
+type SMTPConfig struct {
+	Host     string
+	Port     int
+	User     string
+	Password string
+	From     string
+}
+
+var smtpCfg SMTPConfig
+
+// Configure sets global SMTP settings (call once at startup).
+func Configure(c SMTPConfig) {
+	smtpCfg = c
+	if smtpCfg.Port <= 0 {
+		smtpCfg.Port = 587
+	}
+}
+
+// Configured reports whether SMTP host and from address are set.
+func Configured() bool {
+	return strings.TrimSpace(smtpCfg.Host) != "" && strings.TrimSpace(smtpCfg.From) != ""
+}
+
+// Send delivers a plain-text message to one recipient.
+func Send(ctx context.Context, to, subject, body string) error {
+	to = strings.TrimSpace(to)
+	if to == "" {
+		return fmt.Errorf("recipient required")
+	}
+	if !Configured() {
+		return fmt.Errorf("smtp not configured")
+	}
+	from := strings.TrimSpace(smtpCfg.From)
+	msg := strings.Join([]string{
+		"From: " + from,
+		"To: " + to,
+		"Subject: " + subject,
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		body,
+	}, "\r\n")
+
+	addr := fmt.Sprintf("%s:%d", strings.TrimSpace(smtpCfg.Host), smtpCfg.Port)
+	var auth smtp.Auth
+	if u := strings.TrimSpace(smtpCfg.User); u != "" {
+		auth = smtp.PlainAuth("", u, smtpCfg.Password, smtpCfg.Host)
+	}
+
+	if smtpCfg.Port == 465 {
+		return sendSMTPS(addr, auth, from, []string{to}, []byte(msg))
+	}
+	if err := smtp.SendMail(addr, auth, from, []string{to}, []byte(msg)); err != nil {
+		applog.Warn(ctx, applog.Event{
+			Message:   "smtp send failed",
+			Component: "mail",
+			Operation: "send",
+			Status:    "failed",
+			Context:   map[string]interface{}{"to": to, "subject": subject},
+			Err:       err,
+		})
+		return err
+	}
+	return nil
+}
+
+func sendSMTPS(addr string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return err
+	}
+	conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: host})
+	if err != nil {
+		return err
+	}
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	if auth != nil {
+		if err := client.Auth(auth); err != nil {
+			return err
+		}
+	}
+	if err := client.Mail(from); err != nil {
+		return err
+	}
+	for _, rcpt := range to {
+		if err := client.Rcpt(rcpt); err != nil {
+			return err
+		}
+	}
+	w, err := client.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(msg); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return client.Quit()
+}
+
+// SendPasswordResetEmail notifies a user that an administrator requested a password reset.
+func SendPasswordResetEmail(ctx context.Context, to, login, loginURL string) error {
+	subject := "Sumeru password reset requested"
+	body := fmt.Sprintf("Hello,\n\nAn administrator requested a password reset for account %q.\n\nSign in at: %s\n\nIf you did not expect this message, contact your administrator.\n", login, loginURL)
+	return Send(ctx, to, subject, body)
+}

--- a/core/mail/worker.go
+++ b/core/mail/worker.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"context"
+	"encoding/json"
+
+	"sumeru/core/applog"
+	"sumeru/core/queue"
+)
+
+func init() {
+	queue.Subscribe("mail", deliverQueuedMail)
+}
+
+type mailJob struct {
+	To      string `json:"to"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+func deliverQueuedMail(ctx context.Context, msg queue.Message) error {
+	var job mailJob
+	if err := json.Unmarshal(msg.Payload, &job); err != nil {
+		return err
+	}
+	if err := Send(ctx, job.To, job.Subject, job.Body); err != nil {
+		applog.Warn(ctx, applog.Event{
+			Message:   "queued mail delivery failed",
+			Component: "mail",
+			Operation: "queue_worker",
+			Status:    "failed",
+			Err:       err,
+		})
+		return err
+	}
+	return nil
+}
+
+// Enqueue sends mail asynchronously via the in-process queue worker.
+func Enqueue(ctx context.Context, to, subject, body string) {
+	queue.Publish(ctx, "mail", mailJob{To: to, Subject: subject, Body: body})
+}

--- a/core/module/cli.go
+++ b/core/module/cli.go
@@ -46,12 +46,9 @@ func UpdateModuleData(ctx context.Context, name string) error {
 func RunModuleCLI(installCSV, updateCSV string) error {
 	ctx := orm.ContextWithBypass(context.Background(), true)
 
-	installNames := splitCSV(installCSV)
-	// "-i all" is explicitly blocked. Module installs require exact names.
-	for _, name := range installNames {
-		if strings.EqualFold(name, "all") {
-			return fmt.Errorf("-i all is not supported; specify module names explicitly (e.g. -i sales,crm)")
-		}
+	installNames, err := expandInstallModuleNames(ctx, splitCSV(installCSV))
+	if err != nil {
+		return err
 	}
 
 	for _, name := range installNames {
@@ -197,6 +194,67 @@ func orderModulesForUpdate(names []string) []string {
 	}
 	sort.Strings(rest)
 	return append(ordered, rest...)
+}
+
+// expandInstallModuleNames resolves -i all into uninstalled module names in dependency order.
+func expandInstallModuleNames(ctx context.Context, parts []string) ([]string, error) {
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	var installedSet map[string]struct{}
+	loadInstalled := func() error {
+		if installedSet != nil {
+			return nil
+		}
+		installed, err := listInstalledModuleNames(ctx)
+		if err != nil {
+			return err
+		}
+		installedSet = make(map[string]struct{}, len(installed))
+		for _, n := range installed {
+			installedSet[n] = struct{}{}
+		}
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var raw []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if strings.EqualFold(p, "all") {
+			if err := loadInstalled(); err != nil {
+				return nil, err
+			}
+			topo, err := sortAddonsTopo(DiscoveredAddons)
+			if err != nil {
+				return nil, err
+			}
+			for _, a := range topo {
+				n := a.Manifest.Name
+				if _, ok := installedSet[n]; ok {
+					continue
+				}
+				if _, ok := seen[n]; ok {
+					continue
+				}
+				seen[n] = struct{}{}
+				raw = append(raw, n)
+			}
+			continue
+		}
+		if _, ok := DiscoveredAddons[p]; !ok {
+			return nil, fmt.Errorf("unknown module %q", p)
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		raw = append(raw, p)
+	}
+	return orderModulesForUpdate(raw), nil
 }
 
 func splitCSV(s string) []string {

--- a/core/module/cli_install_all_test.go
+++ b/core/module/cli_install_all_test.go
@@ -1,0 +1,27 @@
+package module_test
+
+import (
+	"context"
+	"testing"
+
+	"sumeru/core/module"
+)
+
+func TestExpandInstallModuleNamesExplicitOrder(t *testing.T) {
+	module.DiscoveredAddons = map[string]*module.Addon{
+		"base": {Manifest: module.Manifest{Name: "base", Depends: []string{}}},
+		"mail": {Manifest: module.Manifest{Name: "mail", Depends: []string{"base"}}},
+		"crm":  {Manifest: module.Manifest{Name: "crm", Depends: []string{"base", "mail"}}},
+	}
+	ctx := context.Background()
+	names, err := module.ExpandInstallModuleNamesForTest(ctx, []string{"crm", "mail"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 modules, got %v", names)
+	}
+	if names[0] != "mail" || names[1] != "crm" {
+		t.Fatalf("unexpected order: %v", names)
+	}
+}

--- a/core/module/data_sync.go
+++ b/core/module/data_sync.go
@@ -11,8 +11,11 @@ import (
 	"sumeru/core/orm"
 )
 
-func processXMLRecords(ctx context.Context, moduleName string, records []parser.Record, inheritQueue *[]parser.Record) {
+func processXMLRecords(ctx context.Context, moduleName string, records []parser.Record, inheritQueue *[]parser.Record, opts dataFileOpts) {
 	for _, xmlRecord := range records {
+		if opts.skipExistingOnUpdate(ctx, moduleName, xmlRecord.ID) {
+			continue
+		}
 		if xmlRecord.Model == "sys.action.window" {
 			upsertSysActionWindowFromRecord(ctx, moduleName, xmlRecord)
 		}
@@ -43,10 +46,11 @@ func RecordsFromActions(actions []parser.Action) []parser.Record {
 func loadManifestDataFile(ctx context.Context, moduleName, xmlPath, relFile string, inheritQueue *[]parser.Record, menuCollector *[]parser.MenuItem) []error {
 	parsedViewData, viewErr := parser.ParseViewList(xmlPath)
 	if viewErr == nil {
+		opts := dataFileOpts{noUpdate: parsedViewData.NoUpdate}
 		records := append([]parser.Record(nil), parsedViewData.Records...)
 		records = append(records, RecordsFromActions(parsedViewData.Actions)...)
 		if len(records) > 0 || len(parsedViewData.Views) > 0 || len(parsedViewData.MenuItems) > 0 {
-			processXMLRecords(ctx, moduleName, records, inheritQueue)
+			processXMLRecords(ctx, moduleName, records, inheritQueue, opts)
 			for i := range parsedViewData.Views {
 				upsertInlineViewDef(ctx, moduleName, &parsedViewData.Views[i])
 			}
@@ -61,13 +65,14 @@ func loadManifestDataFile(ctx context.Context, moduleName, xmlPath, relFile stri
 
 	menuList, menuErr := parser.ParseMenuList(xmlPath)
 	if menuErr == nil {
+		opts := dataFileOpts{noUpdate: menuList.NoUpdate}
 		records := append([]parser.Record(nil), menuList.Records...)
 		records = append(records, RecordsFromActions(menuList.Actions)...)
 		if len(menuList.MenuItems) > 0 || len(records) > 0 {
 			if len(menuList.MenuItems) > 0 {
 				*menuCollector = append(*menuCollector, menuList.MenuItems...)
 			}
-			processXMLRecords(ctx, moduleName, records, inheritQueue)
+			processXMLRecords(ctx, moduleName, records, inheritQueue, opts)
 			return nil
 		}
 		return nil

--- a/core/module/export_test.go
+++ b/core/module/export_test.go
@@ -1,0 +1,8 @@
+package module
+
+import "context"
+
+// ExpandInstallModuleNamesForTest exposes expandInstallModuleNames for tests.
+func ExpandInstallModuleNamesForTest(ctx context.Context, parts []string) ([]string, error) {
+	return expandInstallModuleNames(ctx, parts)
+}

--- a/core/module/install.go
+++ b/core/module/install.go
@@ -123,6 +123,7 @@ func loadModuleXMLData(ctx context.Context, moduleName string, mode moduleReload
 			return err
 		}
 	}
+	ctx = ContextWithSyncMode(ctx, mode)
 	return recordSyncToDBResult(ctx, moduleName, addon.SyncToDB(ctx))
 }
 

--- a/core/module/install.go
+++ b/core/module/install.go
@@ -89,6 +89,9 @@ func reloadModuleData(ctx context.Context, moduleName string, mode moduleReloadM
 	if err := syncModuleSchema(ctx, moduleName, mode); err != nil {
 		return err
 	}
+	if err := RunModuleMigrations(ctx, moduleName); err != nil {
+		return fmt.Errorf("migrations: %w", err)
+	}
 	if err := loadModuleXMLData(ctx, moduleName, mode, addon); err != nil {
 		return err
 	}

--- a/core/module/migrate.go
+++ b/core/module/migrate.go
@@ -1,0 +1,119 @@
+package module
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"sumeru/core/orm"
+)
+
+const migrationTable = "sys_migration"
+
+// EnsureMigrationTable creates the migration tracking table if missing.
+func EnsureMigrationTable(ctx context.Context) error {
+	if orm.DB == nil {
+		return fmt.Errorf("database not connected")
+	}
+	_, err := orm.DB.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS sys_migration (
+			module TEXT NOT NULL,
+			name TEXT NOT NULL,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (module, name)
+		)`)
+	return err
+}
+
+func migrationApplied(ctx context.Context, moduleName, name string) (bool, error) {
+	var n int
+	err := orm.DB.QueryRowContext(ctx,
+		`SELECT 1 FROM sys_migration WHERE module = $1 AND name = $2`, moduleName, name,
+	).Scan(&n)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func markMigrationApplied(ctx context.Context, moduleName, name string) error {
+	_, err := orm.DB.ExecContext(ctx,
+		`INSERT INTO sys_migration (module, name) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		moduleName, name)
+	return err
+}
+
+// RunModuleMigrations applies pending SQL files from addons/MODULE/migrations/*.sql.
+func RunModuleMigrations(ctx context.Context, moduleName string) error {
+	addon, ok := DiscoveredAddons[moduleName]
+	if !ok {
+		return fmt.Errorf("unknown module %q", moduleName)
+	}
+	dir := filepath.Join(addon.Path, "migrations")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".sql") {
+			continue
+		}
+		files = append(files, e.Name())
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		return nil
+	}
+	if err := EnsureMigrationTable(ctx); err != nil {
+		return err
+	}
+	for _, name := range files {
+		applied, err := migrationApplied(ctx, moduleName, name)
+		if err != nil {
+			return err
+		}
+		if applied {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return fmt.Errorf("read migration %s: %w", name, err)
+		}
+		sqlText := strings.TrimSpace(string(body))
+		if sqlText == "" {
+			continue
+		}
+		if _, err := orm.DB.ExecContext(ctx, sqlText); err != nil {
+			return fmt.Errorf("migration %s/%s: %w", moduleName, name, err)
+		}
+		if err := markMigrationApplied(ctx, moduleName, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunAllMigrations applies migrations for every discovered addon in dependency order.
+func RunAllMigrations(ctx context.Context) error {
+	topo, err := sortAddonsTopo(DiscoveredAddons)
+	if err != nil {
+		return err
+	}
+	for _, a := range topo {
+		if err := RunModuleMigrations(ctx, a.Manifest.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/core/module/module_info.go
+++ b/core/module/module_info.go
@@ -1,0 +1,103 @@
+package module
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"sumeru/core/orm"
+)
+
+// ModuleInfo describes one addon on disk and optional DB state.
+type ModuleInfo struct {
+	Name        string
+	Version     string
+	State       string
+	Depends     []string
+	Application bool
+}
+
+// ListModuleInfo returns discovered addons sorted by name with installed state when DB is available.
+func ListModuleInfo(ctx context.Context) ([]ModuleInfo, error) {
+	names := make([]string, 0, len(DiscoveredAddons))
+	for n := range DiscoveredAddons {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	states := map[string]string{}
+	if orm.DB != nil && orm.IsInitialized() {
+		rows, err := orm.DB.QueryContext(ctx,
+			`SELECT name, state FROM `+orm.MustQuotedTableName("sys.module"))
+		if err == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var name, state string
+				if err := rows.Scan(&name, &state); err == nil {
+					states[name] = state
+				}
+			}
+		}
+	}
+	out := make([]ModuleInfo, 0, len(names))
+	for _, n := range names {
+		a := DiscoveredAddons[n]
+		st := states[n]
+		if st == "" {
+			st = "uninstalled"
+		}
+		app := false
+		if a.Manifest.Application != nil {
+			app = *a.Manifest.Application
+		}
+		out = append(out, ModuleInfo{
+			Name:        a.Manifest.Name,
+			Version:     a.Manifest.Version,
+			State:       st,
+			Depends:     append([]string(nil), a.Manifest.Depends...),
+			Application: app,
+		})
+	}
+	return out, nil
+}
+
+// DependsTree prints dependency tree for moduleName.
+func DependsTree(moduleName string) (string, error) {
+	moduleName = strings.TrimSpace(moduleName)
+	if moduleName == "" {
+		return "", fmt.Errorf("module name required")
+	}
+	var b strings.Builder
+	var walk func(name string, depth int, seen map[string]struct{}) error
+	walk = func(name string, depth int, seen map[string]struct{}) error {
+		if _, ok := seen[name]; ok {
+			b.WriteString(strings.Repeat("  ", depth) + name + " (cycle)\n")
+			return nil
+		}
+		seen[name] = struct{}{}
+		a, ok := DiscoveredAddons[name]
+		if !ok {
+			b.WriteString(strings.Repeat("  ", depth) + name + " (missing)\n")
+			return nil
+		}
+		b.WriteString(strings.Repeat("  ", depth) + name + "\n")
+		for _, dep := range a.Manifest.Depends {
+			dep = strings.TrimSpace(dep)
+			if dep == "" {
+				continue
+			}
+			childSeen := map[string]struct{}{}
+			for k, v := range seen {
+				childSeen[k] = v
+			}
+			if err := walk(dep, depth+1, childSeen); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := walk(moduleName, 0, map[string]struct{}{}); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/core/module/sync_mode.go
+++ b/core/module/sync_mode.go
@@ -1,0 +1,34 @@
+package module
+
+import (
+	"context"
+
+	"sumeru/core/orm"
+)
+
+type syncModeKey struct{}
+
+// ContextWithSyncMode attaches install/update reload mode to ctx for data sync.
+func ContextWithSyncMode(ctx context.Context, mode moduleReloadMode) context.Context {
+	return context.WithValue(ctx, syncModeKey{}, mode)
+}
+
+// SyncModeFromContext returns moduleReloadInstall when unset.
+func SyncModeFromContext(ctx context.Context) moduleReloadMode {
+	if v, ok := ctx.Value(syncModeKey{}).(moduleReloadMode); ok {
+		return v
+	}
+	return moduleReloadInstall
+}
+
+type dataFileOpts struct {
+	noUpdate bool
+}
+
+func (o dataFileOpts) skipExistingOnUpdate(ctx context.Context, moduleName, xmlID string) bool {
+	if SyncModeFromContext(ctx) != moduleReloadUpdate || !o.noUpdate || xmlID == "" {
+		return false
+	}
+	existingID, _, err := orm.ResolveXmlId(ctx, moduleName+"."+xmlID)
+	return err == nil && existingID > 0
+}

--- a/core/module/sync_mode_test.go
+++ b/core/module/sync_mode_test.go
@@ -1,0 +1,31 @@
+package module
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDataFileOptsSkipExistingOnUpdate(t *testing.T) {
+	opts := dataFileOpts{noUpdate: true}
+	ctx := ContextWithSyncMode(context.Background(), moduleReloadUpdate)
+	if opts.skipExistingOnUpdate(ctx, "base", "") {
+		t.Fatal("empty xml id should not skip")
+	}
+	ctxInstall := ContextWithSyncMode(context.Background(), moduleReloadInstall)
+	if opts.skipExistingOnUpdate(ctxInstall, "base", "company_main") {
+		t.Fatal("install mode should not skip")
+	}
+	if opts.skipExistingOnUpdate(ctx, "base", "company_main") {
+		// without DB/xml id resolution this returns false — no skip when id unknown
+	}
+	opts2 := dataFileOpts{noUpdate: false}
+	if opts2.skipExistingOnUpdate(ctx, "base", "company_main") {
+		t.Fatal("noUpdate false should not skip")
+	}
+}
+
+func TestSyncModeFromContextDefault(t *testing.T) {
+	if SyncModeFromContext(context.Background()) != moduleReloadInstall {
+		t.Fatal("expected install default")
+	}
+}

--- a/core/orm/computed.go
+++ b/core/orm/computed.go
@@ -1,0 +1,82 @@
+package orm
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// ComputeFunc derives a stored or read-time field value from a record map.
+type ComputeFunc func(ctx context.Context, rec map[string]interface{}) (interface{}, error)
+
+type computeSpec struct {
+	deps []string
+	fn   ComputeFunc
+}
+
+var (
+	computeMu sync.RWMutex
+	computes  = map[string]map[string]computeSpec{} // model -> field -> spec
+)
+
+// RegisterCompute registers a computed field for model.
+// deps lists field names that trigger recomputation when present in writes.
+func RegisterCompute(model, field string, deps []string, fn ComputeFunc) {
+	model = strings.TrimSpace(model)
+	field = strings.TrimSpace(field)
+	if model == "" || field == "" || fn == nil {
+		return
+	}
+	computeMu.Lock()
+	defer computeMu.Unlock()
+	if computes[model] == nil {
+		computes[model] = map[string]computeSpec{}
+	}
+	computes[model][field] = computeSpec{deps: append([]string(nil), deps...), fn: fn}
+}
+
+// ApplyComputes fills registered computed fields on rec (in place).
+func ApplyComputes(ctx context.Context, model string, rec map[string]interface{}) error {
+	if rec == nil {
+		return nil
+	}
+	computeMu.RLock()
+	byField := computes[model]
+	if len(byField) == 0 {
+		computeMu.RUnlock()
+		return nil
+	}
+	specs := make(map[string]computeSpec, len(byField))
+	for k, v := range byField {
+		specs[k] = v
+	}
+	computeMu.RUnlock()
+	for field, spec := range specs {
+		val, err := spec.fn(ctx, rec)
+		if err != nil {
+			return fmt.Errorf("compute %s.%s: %w", model, field, err)
+		}
+		rec[field] = val
+	}
+	return nil
+}
+
+// ComputeDeps returns dependency field names for a model's computed fields.
+func ComputeDeps(model string) []string {
+	computeMu.RLock()
+	defer computeMu.RUnlock()
+	seen := map[string]struct{}{}
+	for _, spec := range computes[model] {
+		for _, d := range spec.deps {
+			seen[d] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core/orm/crud_domain.go
+++ b/core/orm/crud_domain.go
@@ -100,6 +100,14 @@ func buildSearchWhereClause(modelName string, domain [][]interface{}) (string, [
 				n++
 			}
 			parts = append(parts, fmt.Sprintf("%s IN (%s)", col, strings.Join(ph, ",")))
+		case "ilike", "like":
+			parts = append(parts, fmt.Sprintf("%s ILIKE $%d", col, n))
+			args = append(args, d[2])
+			n++
+		case "=like":
+			parts = append(parts, fmt.Sprintf("%s LIKE $%d", col, n))
+			args = append(args, d[2])
+			n++
 		default:
 			return "", nil, fmt.Errorf("unsupported domain operator %q", op)
 		}

--- a/core/orm/crud_search.go
+++ b/core/orm/crud_search.go
@@ -25,6 +25,7 @@ type searchPaging struct {
 }
 
 func execSearchQuery(ctx context.Context, modelName string, domain [][]interface{}, paging *searchPaging) ([]map[string]interface{}, error) {
+	ctx = ContextWithReadReplica(ctx, true)
 	if _, ok := Registry[modelName]; !ok {
 		return nil, fmt.Errorf("model %s not found", modelName)
 	}
@@ -56,7 +57,7 @@ func execSearchQuery(ctx context.Context, modelName string, domain [][]interface
 		query += fmt.Sprintf(" ORDER BY %s LIMIT $%d OFFSET $%d", paging.orderBySQL, n, n+1)
 		args = append(args, paging.limit, paging.offset)
 	}
-	rows, err := DB.QueryContext(ctx, query, args...)
+	rows, err := QueryDB(ctx).QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +71,7 @@ func execSearchQuery(ctx context.Context, modelName string, domain [][]interface
 			return nil, err
 		}
 		RedactRecordForRead(ctx, uid, modelName, m)
+		_ = ApplyComputes(ctx, modelName, m)
 		results = append(results, m)
 	}
 	return results, rows.Err()

--- a/core/orm/crud_search_one.go
+++ b/core/orm/crud_search_one.go
@@ -76,5 +76,6 @@ func SearchOne(ctx context.Context, modelName string, criteria map[string]interf
 		return nil, err
 	}
 	RedactRecordForRead(ctx, uid, modelName, result)
+	_ = ApplyComputes(ctx, modelName, result)
 	return result, nil
 }

--- a/core/orm/db.go
+++ b/core/orm/db.go
@@ -3,25 +3,92 @@ package orm
 import (
 	"context"
 	"database/sql"
+	"strings"
+	"time"
+
 	_ "github.com/lib/pq"
 
 	"sumeru/core/applog"
 )
 
+// DBPoolSettings configures the PostgreSQL connection pool.
+type DBPoolSettings struct {
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+}
+
 var DB DBWrapper
+var readDB DBWrapper
+var readReplicaReady bool
 
 func InitDB(connStr string) {
+	InitDBWithPool(connStr, DBPoolSettings{})
+}
+
+// InitDBWithPool opens the primary pool and optionally configures limits.
+func InitDBWithPool(connStr string, pool DBPoolSettings) {
 	rawDB, err := sql.Open("postgres", connStr)
 	if err != nil {
 		applog.Fatal(context.Background(), "db_open", "err", err)
 	}
-
+	applyPoolSettings(rawDB, pool)
 	DB = NewDBWrapper(rawDB)
-
-	err = DB.Ping()
-	if err != nil {
+	if err := DB.Ping(); err != nil {
 		applog.Fatal(context.Background(), "db_ping", "err", err)
 	}
-
 	applog.InfoMsg(context.Background(), "orm", "connect", "Successfully connected to the database", nil)
+}
+
+// InitReadReplica opens an optional read-only replica pool for search-heavy paths.
+func InitReadReplica(connStr string, pool DBPoolSettings) {
+	connStr = strings.TrimSpace(connStr)
+	if connStr == "" {
+		readDB = nil
+		readReplicaReady = false
+		return
+	}
+	rawDB, err := sql.Open("postgres", connStr)
+	if err != nil {
+		applog.Fatal(context.Background(), "db_read_open", "err", err)
+	}
+	applyPoolSettings(rawDB, pool)
+	readDB = NewDBWrapper(rawDB)
+	if err := readDB.Ping(); err != nil {
+		applog.Fatal(context.Background(), "db_read_ping", "err", err)
+	}
+	readReplicaReady = true
+	applog.InfoMsg(context.Background(), "orm", "connect", "Read replica connected", nil)
+}
+
+func applyPoolSettings(db *sql.DB, pool DBPoolSettings) {
+	if pool.MaxOpenConns > 0 {
+		db.SetMaxOpenConns(pool.MaxOpenConns)
+	}
+	if pool.MaxIdleConns > 0 {
+		db.SetMaxIdleConns(pool.MaxIdleConns)
+	}
+	if pool.ConnMaxLifetime > 0 {
+		db.SetConnMaxLifetime(pool.ConnMaxLifetime)
+	}
+}
+
+type readReplicaKey struct{}
+
+// ContextWithReadReplica marks ctx to prefer the read replica for Search* queries.
+func ContextWithReadReplica(ctx context.Context, use bool) context.Context {
+	return context.WithValue(ctx, readReplicaKey{}, use)
+}
+
+func useReadReplica(ctx context.Context) bool {
+	v, _ := ctx.Value(readReplicaKey{}).(bool)
+	return v && readReplicaReady
+}
+
+// QueryDB returns read replica when ctx requests it and replica is configured.
+func QueryDB(ctx context.Context) DBWrapper {
+	if useReadReplica(ctx) {
+		return readDB
+	}
+	return DB
 }

--- a/core/orm/list_search_domain.go
+++ b/core/orm/list_search_domain.go
@@ -1,0 +1,68 @@
+package orm
+
+import "strings"
+
+// BuildListSearchDomain OR-combines ilike clauses for searchable string fields.
+func BuildListSearchDomain(modelName string, fieldNames []string, query string) [][]interface{} {
+	query = strings.TrimSpace(query)
+	if query == "" || len(fieldNames) == 0 {
+		return nil
+	}
+	pattern := "%" + query + "%"
+	var leaves [][]interface{}
+	for _, f := range fieldNames {
+		f = strings.TrimSpace(f)
+		if f == "" || f == "id" {
+			continue
+		}
+		if !fieldSearchable(modelName, f) {
+			continue
+		}
+		leaves = append(leaves, []interface{}{f, "ilike", pattern})
+	}
+	if len(leaves) == 0 {
+		return nil
+	}
+	if len(leaves) == 1 {
+		return leaves
+	}
+	out := make([][]interface{}, 0, len(leaves)*2-1)
+	for i := 0; i < len(leaves)-1; i++ {
+		out = append(out, []interface{}{"|"})
+	}
+	out = append(out, leaves...)
+	return out
+}
+
+func fieldSearchable(modelName, field string) bool {
+	m, ok := Registry[modelName]
+	if !ok {
+		return false
+	}
+	for _, fd := range m.Fields() {
+		if fd.Name != field {
+			continue
+		}
+		switch fd.Type {
+		case Char, Text:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// MergeDomains AND-combines two domains (base action domain + optional search overlay).
+func MergeDomains(base, extra [][]interface{}) [][]interface{} {
+	if len(extra) == 0 {
+		return base
+	}
+	if len(base) == 0 {
+		return extra
+	}
+	out := make([][]interface{}, 0, len(base)+len(extra))
+	out = append(out, base...)
+	out = append(out, extra...)
+	return out
+}

--- a/core/orm/outbox_drain.go
+++ b/core/orm/outbox_drain.go
@@ -8,6 +8,7 @@ import (
 
 	"sumeru/core/applog"
 	"sumeru/core/event"
+	"sumeru/core/queue"
 )
 
 var (
@@ -57,6 +58,9 @@ func DrainOutboxOnce(ctx context.Context) int {
 			})
 			continue
 		}
+		queue.Publish(bypass, "outbox", map[string]interface{}{
+			"id": id, "name": name, "payload": payload, "actor": actor,
+		})
 		if _, err := DB.ExecContext(bypass,
 			`UPDATE `+tbl+` SET published_at = $1 WHERE id = $2`, now, id); err != nil {
 			continue

--- a/core/orm/outbox_drain.go
+++ b/core/orm/outbox_drain.go
@@ -1,0 +1,103 @@
+package orm
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"sumeru/core/applog"
+	"sumeru/core/event"
+)
+
+var (
+	outboxMu     sync.Mutex
+	outboxCancel context.CancelFunc
+)
+
+// DrainOutboxOnce publishes pending outbox rows (up to 100) and marks them published.
+func DrainOutboxOnce(ctx context.Context) int {
+	if DB == nil {
+		return 0
+	}
+	if _, ok := Registry["sys.outbox.event"]; !ok {
+		return 0
+	}
+	bypass := ContextWithBypass(ctx, true)
+	tbl := MustQuotedTableName("sys.outbox.event")
+	rows, err := DB.QueryContext(bypass,
+		`SELECT id, name, COALESCE(payload_json,''), COALESCE(actor,0) FROM `+tbl+
+			` WHERE published_at IS NULL ORDER BY id LIMIT 100`)
+	if err != nil {
+		return 0
+	}
+	defer rows.Close()
+
+	published := 0
+	now := time.Now().UTC().Format(time.RFC3339)
+	for rows.Next() {
+		var id int64
+		var name, payloadJSON string
+		var actor int
+		if err := rows.Scan(&id, &name, &payloadJSON, &actor); err != nil {
+			continue
+		}
+		payload := map[string]interface{}{}
+		if payloadJSON != "" {
+			_ = json.Unmarshal([]byte(payloadJSON), &payload)
+		}
+		if errs := event.Publish(bypass, event.Event{Name: name, Actor: actor, Payload: payload}); len(errs) > 0 {
+			applog.Warn(bypass, applog.Event{
+				Message:   "outbox publish failed",
+				Component: "orm",
+				Operation: "outbox_drain",
+				Status:    "failed",
+				Context:   map[string]interface{}{"outbox_id": id, "event": name},
+				Err:       errs[0],
+			})
+			continue
+		}
+		if _, err := DB.ExecContext(bypass,
+			`UPDATE `+tbl+` SET published_at = $1 WHERE id = $2`, now, id); err != nil {
+			continue
+		}
+		published++
+	}
+	return published
+}
+
+// StartOutboxDrain begins a background ticker that drains pending outbox rows.
+func StartOutboxDrain(parent context.Context, every time.Duration) {
+	outboxMu.Lock()
+	defer outboxMu.Unlock()
+	if outboxCancel != nil {
+		return
+	}
+	if every <= 0 {
+		every = 5 * time.Second
+	}
+	ctx, cancel := context.WithCancel(parent)
+	outboxCancel = cancel
+	go func() {
+		t := time.NewTicker(every)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				DrainOutboxOnce(ctx)
+			}
+		}
+	}()
+}
+
+// StopOutboxDrain halts the outbox drain goroutine.
+func StopOutboxDrain() {
+	outboxMu.Lock()
+	defer outboxMu.Unlock()
+	if outboxCancel != nil {
+		outboxCancel()
+		outboxCancel = nil
+	}
+}

--- a/core/orm/read_group.go
+++ b/core/orm/read_group.go
@@ -1,0 +1,108 @@
+package orm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ReadGroupSpec defines grouping and aggregation for read_group.
+type ReadGroupSpec struct {
+	GroupBy []string
+	Fields  []ReadGroupField
+}
+
+// ReadGroupField is one aggregate column.
+type ReadGroupField struct {
+	Name    string // output key
+	Field   string // source field
+	Measure string // sum | count
+}
+
+// ReadGroupRow is one grouped result row.
+type ReadGroupRow map[string]interface{}
+
+// ReadGroup aggregates records by group fields with sum/count measures.
+func ReadGroup(ctx context.Context, modelName string, domain [][]interface{}, spec ReadGroupSpec) ([]ReadGroupRow, error) {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		return nil, fmt.Errorf("model required")
+	}
+	if _, ok := Registry[modelName]; !ok {
+		return nil, fmt.Errorf("model %s not found", modelName)
+	}
+	uid := SecurityUID(ctx)
+	if err := CheckModelAccess(ctx, uid, modelName, "read"); err != nil {
+		return nil, err
+	}
+	if len(spec.GroupBy) == 0 {
+		return nil, fmt.Errorf("groupby required")
+	}
+
+	selectParts := []string{}
+	groupCols := []string{}
+	for i, g := range spec.GroupBy {
+		col, err := QuotedColumnForModel(modelName, g)
+		if err != nil {
+			return nil, err
+		}
+		alias := fmt.Sprintf("g%d", i)
+		selectParts = append(selectParts, fmt.Sprintf("%s AS %s", col, alias))
+		groupCols = append(groupCols, col)
+	}
+	for _, f := range spec.Fields {
+		col, err := QuotedColumnForModel(modelName, f.Field)
+		if err != nil {
+			return nil, err
+		}
+		name := strings.TrimSpace(f.Name)
+		if name == "" {
+			name = f.Field
+		}
+		switch strings.ToLower(strings.TrimSpace(f.Measure)) {
+		case "count", "":
+			selectParts = append(selectParts, fmt.Sprintf("COUNT(*) AS %s", quoteIdent(name)))
+		case "sum":
+			selectParts = append(selectParts, fmt.Sprintf("COALESCE(SUM(%s),0) AS %s", col, quoteIdent(name)))
+		default:
+			return nil, fmt.Errorf("unsupported measure %q", f.Measure)
+		}
+	}
+
+	where, args, err := BuildWhereWithRecordRules(ctx, uid, modelName, "read", domain)
+	if err != nil {
+		return nil, err
+	}
+	tbl, err := QuotedTableForModel(modelName)
+	if err != nil {
+		return nil, err
+	}
+	q := fmt.Sprintf("SELECT %s FROM %s WHERE %s GROUP BY %s ORDER BY 1",
+		strings.Join(selectParts, ", "), tbl, where, strings.Join(groupCols, ", "))
+	rows, err := QueryDB(ContextWithReadReplica(ctx, true)).QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	var out []ReadGroupRow
+	for rows.Next() {
+		raw := make([]interface{}, len(cols))
+		ptrs := make([]interface{}, len(cols))
+		for i := range raw {
+			ptrs[i] = &raw[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		row := ReadGroupRow{}
+		for i, c := range cols {
+			row[c] = raw[i]
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}

--- a/core/orm/sys_outbox.go
+++ b/core/orm/sys_outbox.go
@@ -25,7 +25,6 @@ func (SysOutboxEvent) Fields() []FieldDefinition {
 		{Name: "payload_json", Type: Text},
 		{Name: "actor", Type: Integer},
 		{Name: "created_at", Type: DateTime, Required: true},
-		// TODO: outbox drain worker + partial index WHERE published_at IS NULL
 		{Name: "published_at", Type: DateTime, Index: true},
 	}
 }

--- a/core/queue/inproc.go
+++ b/core/queue/inproc.go
@@ -1,0 +1,47 @@
+// Package queue provides an in-process pub/sub bus; optional external brokers can hook Publish.
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+)
+
+// Message is a topic-tagged payload for async workers.
+type Message struct {
+	Topic   string
+	Payload json.RawMessage
+}
+
+type handler func(ctx context.Context, msg Message) error
+
+var (
+	mu       sync.RWMutex
+	handlers = map[string][]handler{}
+)
+
+// Subscribe registers fn for topic (multiple subscribers allowed).
+func Subscribe(topic string, fn func(ctx context.Context, msg Message) error) {
+	mu.Lock()
+	defer mu.Unlock()
+	handlers[topic] = append(handlers[topic], fn)
+}
+
+// Publish dispatches payload to subscribers asynchronously (in-process).
+func Publish(ctx context.Context, topic string, payload interface{}) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	msg := Message{Topic: topic, Payload: data}
+
+	mu.RLock()
+	subs := append([]handler(nil), handlers[topic]...)
+	mu.RUnlock()
+	for _, fn := range subs {
+		fn := fn
+		go func() {
+			_ = fn(ctx, msg)
+		}()
+	}
+}

--- a/core/scheduler/cron_handlers.go
+++ b/core/scheduler/cron_handlers.go
@@ -1,0 +1,43 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+// CronHandler runs when a sys.cron row fires and its code matches a registered handler.
+type CronHandler func(ctx context.Context, payload map[string]interface{}) error
+
+var (
+	cronMu       sync.RWMutex
+	cronHandlers = map[string]CronHandler{}
+)
+
+// RegisterCronHandler binds code (sys.cron code field) to fn.
+func RegisterCronHandler(code string, fn CronHandler) {
+	code = strings.TrimSpace(code)
+	if code == "" || fn == nil {
+		return
+	}
+	cronMu.Lock()
+	defer cronMu.Unlock()
+	cronHandlers[code] = fn
+}
+
+func lookupCronHandler(code string) CronHandler {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return nil
+	}
+	cronMu.RLock()
+	defer cronMu.RUnlock()
+	return cronHandlers[code]
+}
+
+// ClearCronHandlers removes all handlers (tests).
+func ClearCronHandlers() {
+	cronMu.Lock()
+	defer cronMu.Unlock()
+	cronHandlers = map[string]CronHandler{}
+}

--- a/core/scheduler/cron_handlers_test.go
+++ b/core/scheduler/cron_handlers_test.go
@@ -1,0 +1,26 @@
+package scheduler_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"sumeru/core/scheduler"
+)
+
+func TestRegisterCronHandler(t *testing.T) {
+	scheduler.ClearCronHandlers()
+	var called int32
+	scheduler.RegisterCronHandler("test_job", func(_ context.Context, payload map[string]interface{}) error {
+		if payload["code"] != "test_job" {
+			t.Fatalf("unexpected payload: %v", payload)
+		}
+		atomic.StoreInt32(&called, 1)
+		return nil
+	})
+	scheduler.ExecuteCronForTest(context.Background(), 1, "Test", "", "test_job")
+	if atomic.LoadInt32(&called) != 1 {
+		t.Fatal("cron handler was not called")
+	}
+	scheduler.ClearCronHandlers()
+}

--- a/core/scheduler/export_test.go
+++ b/core/scheduler/export_test.go
@@ -1,0 +1,8 @@
+package scheduler
+
+import "context"
+
+// ExecuteCronForTest runs one cron tick handler (tests).
+func ExecuteCronForTest(ctx context.Context, id int64, name, eventName, code string) {
+	executeCron(ctx, id, name, eventName, code)
+}

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -109,4 +109,16 @@ func executeCron(ctx context.Context, id int64, name, eventName, code string) {
 	if eventName = strings.TrimSpace(eventName); eventName != "" {
 		_ = event.Publish(ctx, event.Event{Name: eventName, Payload: payload})
 	}
+	if fn := lookupCronHandler(code); fn != nil {
+		if err := fn(ctx, payload); err != nil {
+			applog.Warn(ctx, applog.Event{
+				Message:   "cron handler failed",
+				Component: "scheduler",
+				Operation: "cron_handler",
+				Status:    "failed",
+				Context:   map[string]interface{}{"cron_id": id, "code": code},
+				Err:       err,
+			})
+		}
+	}
 }

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -1,4 +1,3 @@
-// Package scheduler runs sys.cron jobs on an interval.
 package scheduler
 
 import (
@@ -66,33 +65,56 @@ func runDue(ctx context.Context) {
 	bypass := orm.ContextWithBypass(ctx, true)
 	tbl := orm.MustQuotedTableName("sys.cron")
 	now := time.Now().UTC()
-	rows, err := orm.DB.QueryContext(bypass,
+
+	tx, err := orm.DB.BeginTx(bypass, nil)
+	if err != nil {
+		return
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(bypass,
 		`SELECT id, name, COALESCE(event_name,''), COALESCE(code,'') FROM `+tbl+
-			` WHERE active = true AND (next_call IS NULL OR next_call <= $1)`, now,
+			` WHERE active = true AND (next_call IS NULL OR next_call <= $1)
+			  ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 20`, now,
 	)
 	if err != nil {
 		return
 	}
 	defer rows.Close()
+
+	type cronRow struct {
+		id        int64
+		name      string
+		eventName string
+		code      string
+	}
+	var due []cronRow
 	for rows.Next() {
-		var id int64
-		var name, eventName, code string
-		if err := rows.Scan(&id, &name, &eventName, &code); err != nil {
+		var row cronRow
+		if err := rows.Scan(&row.id, &row.name, &row.eventName, &row.code); err != nil {
 			continue
 		}
-		executeCron(bypass, id, name, eventName, code)
-		interval := cronInterval(bypass, id)
+		due = append(due, row)
+	}
+	if err := rows.Err(); err != nil {
+		return
+	}
+
+	for _, row := range due {
+		executeCron(bypass, row.id, row.name, row.eventName, row.code)
+		interval := cronIntervalTx(bypass, tx, row.id)
 		next := now.Add(interval)
-		_, _ = orm.DB.ExecContext(bypass,
+		_, _ = tx.ExecContext(bypass,
 			`UPDATE `+tbl+` SET next_call = $1, last_call = $2 WHERE id = $3`,
-			next, now, id,
+			next, now, row.id,
 		)
 	}
+	_ = tx.Commit()
 }
 
-func cronInterval(ctx context.Context, id int64) time.Duration {
+func cronIntervalTx(ctx context.Context, tx orm.TxWrapper, id int64) time.Duration {
 	var mins sql.NullInt64
-	_ = orm.DB.QueryRowContext(ctx,
+	_ = tx.QueryRowContext(ctx,
 		`SELECT interval_number FROM `+orm.MustQuotedTableName("sys.cron")+` WHERE id = $1`, id,
 	).Scan(&mins)
 	n := int(mins.Int64)

--- a/core/server/api/dispatch.go
+++ b/core/server/api/dispatch.go
@@ -21,6 +21,8 @@ var PublicMethods = map[string]bool{
 	"create_many":  true,
 	"write_many":   true,
 	"unlink_many":  true,
+	"read_group":   true,
+	"call":         true,
 }
 
 // rpcRequest is the JSON body for POST /api/rpc.
@@ -87,6 +89,10 @@ func dispatchRPC(ctx context.Context, body []byte) (interface{}, error) {
 		return rpcWriteMany(ctx, model, in.Args)
 	case "unlink_many":
 		return rpcUnlinkMany(ctx, model, in.Args)
+	case "read_group":
+		return rpcReadGroup(ctx, model, in.Args, in.Kwargs)
+	case "call":
+		return rpcCall(ctx, model, in.Args)
 	default:
 		return nil, newRPCError(CodeMethodNotAllowed, fmt.Sprintf("unsupported method %q", method), map[string]interface{}{"method": method})
 	}

--- a/core/server/api/method_read_group.go
+++ b/core/server/api/method_read_group.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"sumeru/core/orm"
+)
+
+func rpcReadGroup(ctx context.Context, model string, args json.RawMessage, kwargs json.RawMessage) (interface{}, error) {
+	arr, err := parseArgsArray(args)
+	if err != nil {
+		return nil, err
+	}
+	if len(arr) < 1 {
+		return nil, newRPCError(CodeInvalidArgs, "read_group requires args[0] spec object", map[string]interface{}{"method": "read_group"})
+	}
+	specBytes, _ := json.Marshal(arr[0])
+	var spec struct {
+		Domain  json.RawMessage `json:"domain"`
+		GroupBy []string        `json:"groupby"`
+		Fields  []struct {
+			Name    string `json:"name"`
+			Field   string `json:"field"`
+			Measure string `json:"measure"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(specBytes, &spec); err != nil {
+		return nil, newRPCError(CodeInvalidArgs, fmt.Sprintf("spec: %v", err), map[string]interface{}{"method": "read_group"})
+	}
+	var domain [][]interface{}
+	if len(spec.Domain) > 0 && string(spec.Domain) != "null" {
+		domain, err = orm.ParseDomainJSON(string(spec.Domain))
+		if err != nil {
+			return nil, newRPCError(CodeInvalidArgs, err.Error(), map[string]interface{}{"method": "read_group"})
+		}
+	}
+	rg := orm.ReadGroupSpec{GroupBy: spec.GroupBy}
+	for _, f := range spec.Fields {
+		rg.Fields = append(rg.Fields, orm.ReadGroupField{Name: f.Name, Field: f.Field, Measure: f.Measure})
+	}
+	if len(rg.Fields) == 0 && len(rg.GroupBy) > 0 {
+		rg.Fields = []orm.ReadGroupField{{Name: "__count", Field: "id", Measure: "count"}}
+	}
+	return orm.ReadGroup(ctx, model, domain, rg)
+}
+
+func rpcCall(ctx context.Context, model string, args json.RawMessage) (interface{}, error) {
+	arr, err := parseArgsArray(args)
+	if err != nil {
+		return nil, err
+	}
+	if len(arr) < 2 {
+		return nil, newRPCError(CodeInvalidArgs, "call requires args[0] id and args[1] method", map[string]interface{}{"method": "call"})
+	}
+	var idF float64
+	if err := json.Unmarshal(arr[0], &idF); err != nil || int(idF) <= 0 {
+		return nil, newRPCError(CodeInvalidArgs, "args[0] must be record id", map[string]interface{}{"method": "call"})
+	}
+	var method string
+	if err := json.Unmarshal(arr[1], &method); err != nil || strings.TrimSpace(method) == "" {
+		return nil, newRPCError(CodeInvalidArgs, "args[1] must be method name", map[string]interface{}{"method": "call"})
+	}
+	vals := map[string]string{}
+	if len(arr) >= 3 {
+		var m map[string]interface{}
+		if err := json.Unmarshal(arr[2], &m); err == nil {
+			for k, v := range m {
+				vals[k] = fmt.Sprint(v)
+			}
+		}
+	}
+	redirect, err := orm.RunObjectAction(ctx, model, int(idF), method, vals)
+	if err != nil {
+		return nil, err
+	}
+	if redirect != "" {
+		return map[string]interface{}{"redirect": redirect}, nil
+	}
+	return true, nil
+}

--- a/core/server/api/method_search.go
+++ b/core/server/api/method_search.go
@@ -20,6 +20,7 @@ func rpcSearch(ctx context.Context, model string, args, kwargs json.RawMessage) 
 		}
 	}
 	domain = orm.SubstituteDomainUID(domain, orm.UIDFromContext(ctx))
+	ctx = orm.ContextWithReadReplica(ctx, true)
 	limit, offset := parseLimitOffset(kwargs)
 	return orm.SearchPage(ctx, model, domain, limit, offset, "")
 }

--- a/core/server/api/method_search_read.go
+++ b/core/server/api/method_search_read.go
@@ -21,6 +21,7 @@ func rpcSearchRead(ctx context.Context, model string, args, kwargs json.RawMessa
 		return nil, newRPCError(CodeInvalidArgs, err.Error(), map[string]interface{}{"method": "search_read", "hint": "args[0] domain"})
 	}
 	domain = orm.SubstituteDomainUID(domain, orm.UIDFromContext(ctx))
+	ctx = orm.ContextWithReadReplica(ctx, true)
 	var fields []string
 	if err := json.Unmarshal(arr[1], &fields); err != nil {
 		return nil, newRPCError(CodeInvalidArgs, fmt.Sprintf("args[1] fields: %v", err), map[string]interface{}{"method": "search_read"})

--- a/core/server/cliboot/cliboot.go
+++ b/core/server/cliboot/cliboot.go
@@ -1,0 +1,84 @@
+// Package cliboot initializes config, database, and addons for standalone CLI tools.
+package cliboot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sumeru/core/orm"
+	"sumeru/core/server/config"
+	"sumeru/core/server"
+)
+
+// Init loads INI config, connects to PostgreSQL, syncs models, and discovers addons.
+// Requires an initialized database (not setup mode).
+func Init(configPath string) (context.Context, error) {
+	if err := server.LoadConfig(configPath); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	if err := server.AbsPaths(); err != nil {
+		return nil, fmt.Errorf("paths: %w", err)
+	}
+	c := config.AppConfig
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		c.DbHost, c.DbPort, c.DbUser, c.DbPass, c.DbName, c.DbSslMode)
+	server.InitDatabase(dsn)
+	if !orm.IsInitialized() {
+		return nil, fmt.Errorf("database %q is not initialized; complete /setup first", c.DbName)
+	}
+	if err := server.SyncModels(); err != nil {
+		return nil, fmt.Errorf("sync models: %w", err)
+	}
+	if err := orm.SyncRegistrySchema(); err != nil {
+		return nil, fmt.Errorf("schema sync: %w", err)
+	}
+	if err := server.LoadAddonPaths(config.AppConfig.AddonPaths); err != nil {
+		return nil, fmt.Errorf("addons: %w", err)
+	}
+	ctx := orm.ContextWithBypass(context.Background(), true)
+	if err := orm.EnsureDefaultGroupsAndImplied(); err != nil {
+		return nil, fmt.Errorf("security groups: %w", err)
+	}
+	return ctx, nil
+}
+
+// InitOptionalDB loads config and addons without requiring DB (for list/depends-tree on disk only).
+func InitOptionalDB(configPath string, requireDB bool) (context.Context, error) {
+	if err := server.LoadConfig(configPath); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	if err := server.AbsPaths(); err != nil {
+		return nil, fmt.Errorf("paths: %w", err)
+	}
+	if err := server.LoadAddonPaths(config.AppConfig.AddonPaths); err != nil {
+		return nil, fmt.Errorf("addons: %w", err)
+	}
+	if !requireDB {
+		return context.Background(), nil
+	}
+	return Init(configPath)
+}
+
+// ContextWithUID returns ctx with security uid set for ORM calls.
+func ContextWithUID(ctx context.Context, uid int) context.Context {
+	if uid <= 0 {
+		uid = 1
+	}
+	return orm.ContextWithUID(ctx, uid)
+}
+
+// DSN returns the primary PostgreSQL connection string from loaded config.
+func DSN() string {
+	c := config.AppConfig
+	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		c.DbHost, c.DbPort, c.DbUser, c.DbPass, c.DbName, c.DbSslMode)
+}
+
+// ReadReplicaDSN returns read replica DSN when configured, else primary DSN.
+func ReadReplicaDSN() string {
+	if s := strings.TrimSpace(config.AppConfig.DbReadReplicaDSN); s != "" {
+		return s
+	}
+	return DSN()
+}

--- a/core/server/config/config.go
+++ b/core/server/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	DbName             string
 	DbSslMode          string
 	HttpPort           string
+	HttpInterface      string   // optional bind address; empty = all interfaces (:port)
 	AddonsPath         string   // raw from file: comma-separated addon directory roots (see AddonPaths after AbsPaths)
 	AddonPaths         []string // absolute addon roots from addons_path; filled by AbsPaths()
 	SumeruHome         string   // optional: directory of standard sumeru repo (go.mod); used for default assets/templates if set
@@ -96,6 +97,8 @@ func LoadConfig(path string) error {
 			AppConfig.DbSslMode = val
 		case keyHTTPPort:
 			AppConfig.HttpPort = val
+		case keyHTTPInterface:
+			AppConfig.HttpInterface = val
 		case keyAddonsPath:
 			AppConfig.AddonsPath = val
 		case keySumeruHome:

--- a/core/server/config/config.go
+++ b/core/server/config/config.go
@@ -38,6 +38,16 @@ type Config struct {
 	DevMode            bool     // dev_mode INI key; parseBoolKey(..., false) — debug slog level and dev-only server paths
 	SetupToken         string   // optional secret required for POST /setup/init (header X-Setup-Token or JSON setup_token)
 	SetupLocalhostOnly bool     // when true (default), setup mode listens on 127.0.0.1 only
+	DbMaxOpenConns     int      // db_max_open_conns; 0 = Go default
+	DbMaxIdleConns     int      // db_max_idle_conns; 0 = Go default
+	DbConnMaxLifetimeMin int    // db_conn_max_lifetime_minutes; 0 = no limit
+	DbReadReplicaDSN   string   // optional libpq DSN for read replica (search/read_group RPC)
+	RateLimitRPM       int      // rate_limit_rpm per client IP on /api/rpc and login; 0 = disabled
+	SMTPHost           string
+	SMTPPort           int
+	SMTPUser           string
+	SMTPPassword       string
+	SMTPFrom           string
 }
 
 var AppConfig Config
@@ -143,6 +153,36 @@ func LoadConfig(path string) error {
 			AppConfig.SetupToken = val
 		case keySetupLocalhostOnly:
 			AppConfig.SetupLocalhostOnly = parseBoolKey(val, true)
+		case keyDbMaxOpenConns:
+			if n, err := strconv.Atoi(strings.TrimSpace(val)); err == nil {
+				AppConfig.DbMaxOpenConns = n
+			}
+		case keyDbMaxIdleConns:
+			if n, err := strconv.Atoi(strings.TrimSpace(val)); err == nil {
+				AppConfig.DbMaxIdleConns = n
+			}
+		case keyDbConnMaxLifetimeMin:
+			if n, err := strconv.Atoi(strings.TrimSpace(val)); err == nil {
+				AppConfig.DbConnMaxLifetimeMin = n
+			}
+		case keyDbReadReplicaDSN:
+			AppConfig.DbReadReplicaDSN = val
+		case keyRateLimitRPM:
+			if n, err := strconv.Atoi(strings.TrimSpace(val)); err == nil {
+				AppConfig.RateLimitRPM = n
+			}
+		case keySMTPHost:
+			AppConfig.SMTPHost = val
+		case keySMTPPort:
+			if n, err := strconv.Atoi(strings.TrimSpace(val)); err == nil {
+				AppConfig.SMTPPort = n
+			}
+		case keySMTPUser:
+			AppConfig.SMTPUser = val
+		case keySMTPPassword:
+			AppConfig.SMTPPassword = val
+		case keySMTPFrom:
+			AppConfig.SMTPFrom = val
 		}
 	}
 

--- a/core/server/config/const.go
+++ b/core/server/config/const.go
@@ -36,6 +36,16 @@ const (
 	keyDevMode            = "dev_mode"
 	keySetupToken         = "setup_token"
 	keySetupLocalhostOnly = "setup_localhost_only"
+	keyDbMaxOpenConns     = "db_max_open_conns"
+	keyDbMaxIdleConns     = "db_max_idle_conns"
+	keyDbConnMaxLifetimeMin = "db_conn_max_lifetime_minutes"
+	keyDbReadReplicaDSN   = "db_read_replica_dsn"
+	keyRateLimitRPM       = "rate_limit_rpm"
+	keySMTPHost           = "smtp_host"
+	keySMTPPort           = "smtp_port"
+	keySMTPUser           = "smtp_user"
+	keySMTPPassword       = "smtp_password"
+	keySMTPFrom           = "smtp_from"
 )
 
 const (

--- a/core/server/config/const.go
+++ b/core/server/config/const.go
@@ -16,6 +16,7 @@ const (
 	keyDbName             = "db_name"
 	keyDbSSLMode          = "db_sslmode"
 	keyHTTPPort           = "http_port"
+	keyHTTPInterface      = "http_interface"
 	keyAddonsPath         = "addons_path"
 	keySumeruHome         = "sumeru_home"
 	keyAssetsPath         = "assets_path"

--- a/core/server/dbinit.go
+++ b/core/server/dbinit.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"strings"
+	"time"
+
+	"sumeru/core/mail"
+	"sumeru/core/orm"
+	"sumeru/core/server/config"
+)
+
+// InitDatabase opens the primary pool (and optional read replica) using INI pool settings.
+func InitDatabase(primaryDSN string) {
+	cfg := config.AppConfig
+	pool := orm.DBPoolSettings{
+		MaxOpenConns: cfg.DbMaxOpenConns,
+		MaxIdleConns: cfg.DbMaxIdleConns,
+	}
+	if cfg.DbConnMaxLifetimeMin > 0 {
+		pool.ConnMaxLifetime = time.Duration(cfg.DbConnMaxLifetimeMin) * time.Minute
+	}
+	orm.InitDBWithPool(primaryDSN, pool)
+	if dsn := strings.TrimSpace(cfg.DbReadReplicaDSN); dsn != "" {
+		orm.InitReadReplica(dsn, pool)
+	}
+	mail.Configure(mail.SMTPConfig{
+		Host:     cfg.SMTPHost,
+		Port:     cfg.SMTPPort,
+		User:     cfg.SMTPUser,
+		Password: cfg.SMTPPassword,
+		From:     cfg.SMTPFrom,
+	})
+}

--- a/core/server/export_test.go
+++ b/core/server/export_test.go
@@ -1,0 +1,22 @@
+package server
+
+import "sumeru/core/server/config"
+
+// ListenAddrForTest exposes listenAddr for tests.
+func ListenAddrForTest(host, port string) string {
+	return listenAddr(host, port)
+}
+
+// SetupListenAddrForTest exposes setupListenAddr for tests.
+func SetupListenAddrForTest(cfg config.Config) string {
+	return setupListenAddr(cfg)
+}
+
+// ConfigForTest builds a minimal config for listen tests.
+func ConfigForTest(httpInterface, httpPort string, setupLocalhostOnly bool) config.Config {
+	return config.Config{
+		HttpInterface:      httpInterface,
+		HttpPort:           httpPort,
+		SetupLocalhostOnly: setupLocalhostOnly,
+	}
+}

--- a/core/server/listen_addr_test.go
+++ b/core/server/listen_addr_test.go
@@ -1,0 +1,27 @@
+package server_test
+
+import (
+	"testing"
+
+	"sumeru/core/server"
+)
+
+func TestListenAddr(t *testing.T) {
+	if got := server.ListenAddrForTest("", "8080"); got != ":8080" {
+		t.Fatalf("expected :8080, got %q", got)
+	}
+	if got := server.ListenAddrForTest("127.0.0.1", "8080"); got != "127.0.0.1:8080" {
+		t.Fatalf("expected 127.0.0.1:8080, got %q", got)
+	}
+}
+
+func TestSetupListenAddr(t *testing.T) {
+	cfg := server.ConfigForTest("", "8080", true)
+	if got := server.SetupListenAddrForTest(cfg); got != "127.0.0.1:8080" {
+		t.Fatalf("expected localhost bind, got %q", got)
+	}
+	cfg2 := server.ConfigForTest("0.0.0.0", "8080", true)
+	if got := server.SetupListenAddrForTest(cfg2); got != "0.0.0.0:8080" {
+		t.Fatalf("expected explicit interface, got %q", got)
+	}
+}

--- a/core/server/run.go
+++ b/core/server/run.go
@@ -95,10 +95,7 @@ func Run() {
 		registerBrandingAndStatic()
 		registerSetupRoutes()
 
-		listenHost := ":" + config.AppConfig.HttpPort
-		if config.AppConfig.SetupLocalhostOnly {
-			listenHost = "127.0.0.1:" + config.AppConfig.HttpPort
-		}
+		listenHost := setupListenAddr(config.AppConfig)
 		applog.InfoMsg(ctx, "server", "listen", "Server starting in setup mode",
 			map[string]interface{}{"port": config.AppConfig.HttpPort, "bind": listenHost})
 		setupHandler := web.SecurityMiddleware(nil)
@@ -129,12 +126,14 @@ func Run() {
 	registerBrandingAndStatic()
 	registerAppRoutes()
 	scheduler.Start(context.Background(), time.Minute)
+	orm.StartOutboxDrain(context.Background(), 5*time.Second)
 
+	listenHost := listenAddr(config.AppConfig.HttpInterface, config.AppConfig.HttpPort)
 	applog.InfoMsg(ctx, "server", "listen", "Server starting",
-		map[string]interface{}{"port": config.AppConfig.HttpPort})
+		map[string]interface{}{"port": config.AppConfig.HttpPort, "bind": listenHost})
 	runtime.SyncFromGlobals()
 	appHandler := web.SecurityMiddleware(nil)
-	if err := http.ListenAndServe(":"+config.AppConfig.HttpPort, appHandler); err != nil {
+	if err := http.ListenAndServe(listenHost, appHandler); err != nil {
 		applog.Fatal(ctx, "Server failed", "err", err)
 	}
 }
@@ -145,4 +144,22 @@ func registerAppRoutes() {
 
 func registerSetupRoutes() {
 	web.RegisterSetupRoutes(nil)
+}
+
+func listenAddr(host, port string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ":" + port
+	}
+	return host + ":" + port
+}
+
+func setupListenAddr(cfg config.Config) string {
+	if strings.TrimSpace(cfg.HttpInterface) != "" {
+		return listenAddr(cfg.HttpInterface, cfg.HttpPort)
+	}
+	if cfg.SetupLocalhostOnly {
+		return "127.0.0.1:" + cfg.HttpPort
+	}
+	return listenAddr("", cfg.HttpPort)
 }

--- a/core/server/run.go
+++ b/core/server/run.go
@@ -72,7 +72,7 @@ func Run() {
 	databaseSource := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
 		config.AppConfig.DbHost, config.AppConfig.DbPort, config.AppConfig.DbUser,
 		config.AppConfig.DbPass, config.AppConfig.DbName, config.AppConfig.DbSslMode)
-	InitDB(databaseSource)
+	InitDatabase(databaseSource)
 
 	if orm.IsInitialized() {
 		if err := SyncModels(); err != nil {
@@ -125,6 +125,7 @@ func Run() {
 
 	registerBrandingAndStatic()
 	registerAppRoutes()
+	web.InitRateLimit()
 	scheduler.Start(context.Background(), time.Minute)
 	orm.StartOutboxDrain(context.Background(), 5*time.Second)
 
@@ -133,7 +134,13 @@ func Run() {
 		map[string]interface{}{"port": config.AppConfig.HttpPort, "bind": listenHost})
 	runtime.SyncFromGlobals()
 	appHandler := web.SecurityMiddleware(nil)
-	if err := http.ListenAndServe(listenHost, appHandler); err != nil {
+	srv := &http.Server{
+		Addr:         listenHost,
+		Handler:      appHandler,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
 		applog.Fatal(ctx, "Server failed", "err", err)
 	}
 }

--- a/core/server/web/auth.go
+++ b/core/server/web/auth.go
@@ -13,6 +13,7 @@ import (
 	"sumeru/core/applog"
 	"sumeru/core/engine/assets"
 	"sumeru/core/engine/render"
+	"sumeru/core/mail"
 	"sumeru/core/orm"
 	"sumeru/core/sdk/platformmsg"
 	"sumeru/core/server/config"
@@ -73,6 +74,9 @@ func SecurityMiddleware(next http.Handler) http.Handler {
 		next = http.DefaultServeMux
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !enforceRateLimit(w, r) {
+			return
+		}
 		start := time.Now()
 		requestID := requestIDFromHeader(r)
 		w.Header().Set(requestIDHeader, requestID)
@@ -167,8 +171,21 @@ func ActionResetPassword(w http.ResponseWriter, r *http.Request) {
 
 	userID := strings.TrimSpace(r.PostFormValue(resetUserIDField))
 	loginName := strings.TrimSpace(r.PostFormValue(loginField))
-	WebLogf(r.Context(), resetPasswordRoute,
-		"requested for user id=%s login=%q (email not yet wired)", userID, loginName)
+	to := strings.TrimSpace(r.PostFormValue("email"))
+	if to == "" && strings.Contains(loginName, "@") {
+		to = loginName
+	}
+	loginURL := loginRoute
+	if mail.Configured() && to != "" {
+		if err := mail.SendPasswordResetEmail(r.Context(), to, loginName, loginURL); err != nil {
+			WebLogf(r.Context(), resetPasswordRoute, "email failed for user id=%s: %v", userID, err)
+		} else {
+			WebLogf(r.Context(), resetPasswordRoute, "reset email sent for user id=%s login=%q", userID, loginName)
+		}
+	} else {
+		WebLogf(r.Context(), resetPasswordRoute,
+			"requested for user id=%s login=%q (configure smtp_host/smtp_from to send email)", userID, loginName)
+	}
 	redirectWithWebMessage(w, r, r.PostFormValue(nextField), resetPasswordMsg)
 }
 

--- a/core/server/web/list_search.go
+++ b/core/server/web/list_search.go
@@ -1,0 +1,59 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"sumeru/core/engine/parser"
+	"sumeru/core/orm"
+)
+
+const workspaceListSearchParam = "q"
+
+func listSearchQuery(r *http.Request) string {
+	return strings.TrimSpace(r.URL.Query().Get(workspaceListSearchParam))
+}
+
+func listSearchFieldNames(view *parser.View) []string {
+	if view == nil {
+		return nil
+	}
+	out := make([]string, 0, len(view.Field))
+	for _, f := range view.Field {
+		if n := strings.TrimSpace(f.Name); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func workspaceListDomain(ctx context.Context, actionData map[string]interface{}, view *parser.View, searchQuery string) [][]interface{} {
+	base := actionListDomain(ctx, actionData)
+	if searchQuery == "" || view == nil {
+		return base
+	}
+	search := orm.BuildListSearchDomain(view.Model, listSearchFieldNames(view), searchQuery)
+	return orm.MergeDomains(base, search)
+}
+
+func workspaceListSearchURL(actionID int, menuID, searchQuery string) string {
+	vals := url.Values{}
+	if actionID > 0 {
+		vals.Set(workspaceActionParam, strconv.Itoa(actionID))
+	}
+	if menuID = strings.TrimSpace(menuID); menuID != "" {
+		vals.Set(workspaceMenuIDParam, menuID)
+	}
+	vals.Set(workspaceViewTypeParam, workspaceViewModeList)
+	if searchQuery = strings.TrimSpace(searchQuery); searchQuery != "" {
+		vals.Set(workspaceListSearchParam, searchQuery)
+	}
+	encoded := vals.Encode()
+	if encoded == "" {
+		return workspaceRoute
+	}
+	return workspaceRoute + "?" + encoded
+}

--- a/core/server/web/ratelimit.go
+++ b/core/server/web/ratelimit.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"sumeru/core/server/config"
+)
+
+type rateBucket struct {
+	count   int
+	window  time.Time
+}
+
+var (
+	rateMu      sync.Mutex
+	rateByIP    = map[string]*rateBucket{}
+	rateLimitOn bool
+	rateLimitRPM int
+)
+
+// InitRateLimit reads rate_limit_rpm from loaded config.
+func InitRateLimit() {
+	rateLimitRPM = config.AppConfig.RateLimitRPM
+	rateLimitOn = rateLimitRPM > 0
+}
+
+func rateLimitedPath(path string) bool {
+	switch path {
+	case apiRPCRoute, loginRoute:
+		return true
+	default:
+		return false
+	}
+}
+
+func allowRate(clientIP string) bool {
+	if !rateLimitOn {
+		return true
+	}
+	clientIP = strings.TrimSpace(clientIP)
+	if clientIP == "" {
+		clientIP = "unknown"
+	}
+	now := time.Now()
+	rateMu.Lock()
+	defer rateMu.Unlock()
+	b, ok := rateByIP[clientIP]
+	if !ok || now.Sub(b.window) >= time.Minute {
+		rateByIP[clientIP] = &rateBucket{count: 1, window: now}
+		return true
+	}
+	if b.count >= rateLimitRPM {
+		return false
+	}
+	b.count++
+	return true
+}
+
+func enforceRateLimit(w http.ResponseWriter, r *http.Request) bool {
+	if !rateLimitedPath(r.URL.Path) {
+		return true
+	}
+	if allowRate(clientIP(r)) {
+		return true
+	}
+	http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+	return false
+}

--- a/core/server/web/web_constants.go
+++ b/core/server/web/web_constants.go
@@ -204,6 +204,7 @@ const (
 	workspaceViewModeList   = "list"
 	workspaceViewModeForm   = "form"
 	workspaceViewModeKanban = "kanban"
+	workspaceViewModePivot  = "pivot"
 	maxWorkspaceListRows    = 500
 	maxWorkspaceKanbanRows  = 200
 )

--- a/core/server/web/workspace_load.go
+++ b/core/server/web/workspace_load.go
@@ -14,21 +14,23 @@ import (
 )
 
 type workspaceRequest struct {
-	actionID int
-	menuID   string
-	viewType string
-	recordID string
-	formEdit bool
+	actionID   int
+	menuID     string
+	viewType   string
+	recordID   string
+	formEdit   bool
+	listSearch string
 }
 
 func parseWorkspaceRequest(r *http.Request, actionID int) workspaceRequest {
 	query := r.URL.Query()
 	return workspaceRequest{
-		actionID: actionID,
-		menuID:   query.Get(workspaceMenuIDParam),
-		viewType: strings.TrimSpace(query.Get(workspaceViewTypeParam)),
-		recordID: strings.TrimSpace(query.Get(workspaceRecordIDParam)),
-		formEdit: strings.TrimSpace(query.Get(workspaceEditParam)) == workspaceEditEnabledValue,
+		actionID:   actionID,
+		menuID:     query.Get(workspaceMenuIDParam),
+		viewType:   strings.TrimSpace(query.Get(workspaceViewTypeParam)),
+		recordID:   strings.TrimSpace(query.Get(workspaceRecordIDParam)),
+		formEdit:   strings.TrimSpace(query.Get(workspaceEditParam)) == workspaceEditEnabledValue,
+		listSearch: listSearchQuery(r),
 	}
 }
 
@@ -206,7 +208,9 @@ func loadViewModeData(ctx context.Context, viewRecord *render.ViewRecordData, re
 	case workspaceViewModeForm:
 		return loadWorkspaceFormData(ctx, viewRecord, resolved.targetModel, req.recordID, actionData)
 	case workspaceViewModeList:
-		return loadWorkspaceListData(ctx, viewRecord, resolved.targetModel, actionData, maxWorkspaceListRows)
+		viewRecord.ListSearchQuery = req.listSearch
+		viewRecord.ListSearchURL = workspaceListSearchURL(req.actionID, req.menuID, req.listSearch)
+		return loadWorkspaceListData(ctx, viewRecord, resolved.targetModel, actionData, resolved.view, req.listSearch, maxWorkspaceListRows)
 	case workspaceViewModeKanban:
 		return loadWorkspaceKanbanData(ctx, viewRecord, resolved, actionData)
 	case workspaceViewModePivot:
@@ -254,8 +258,8 @@ func loadWorkspaceFormRecord(ctx context.Context, targetModel, recordIDRaw strin
 	return record, nil
 }
 
-func loadWorkspaceListData(ctx context.Context, viewRecord *render.ViewRecordData, targetModel string, actionData map[string]interface{}, rowLimit int) error {
-	rows, err := searchWorkspaceRows(ctx, targetModel, actionData, rowLimit)
+func loadWorkspaceListData(ctx context.Context, viewRecord *render.ViewRecordData, targetModel string, actionData map[string]interface{}, view *parser.View, searchQuery string, rowLimit int) error {
+	rows, err := searchWorkspaceRowsWithSearch(ctx, targetModel, actionData, view, searchQuery, rowLimit)
 	if err != nil {
 		return fmt.Errorf("list load: %w", err)
 	}
@@ -288,6 +292,11 @@ func loadWorkspacePivotData(ctx context.Context, viewRecord *render.ViewRecordDa
 	return nil
 }
 
+func searchWorkspaceRowsWithSearch(ctx context.Context, targetModel string, actionData map[string]interface{}, view *parser.View, searchQuery string, rowLimit int) ([]map[string]interface{}, error) {
+	domain := workspaceListDomain(ctx, actionData, view, searchQuery)
+	return orm.SearchLimit(ctx, targetModel, domain, rowLimit)
+}
+
 func searchWorkspaceRows(ctx context.Context, targetModel string, actionData map[string]interface{}, rowLimit int) ([]map[string]interface{}, error) {
-	return orm.SearchLimit(ctx, targetModel, actionListDomain(ctx, actionData), rowLimit)
+	return searchWorkspaceRowsWithSearch(ctx, targetModel, actionData, nil, "", rowLimit)
 }

--- a/core/server/web/workspace_load.go
+++ b/core/server/web/workspace_load.go
@@ -209,6 +209,8 @@ func loadViewModeData(ctx context.Context, viewRecord *render.ViewRecordData, re
 		return loadWorkspaceListData(ctx, viewRecord, resolved.targetModel, actionData, maxWorkspaceListRows)
 	case workspaceViewModeKanban:
 		return loadWorkspaceKanbanData(ctx, viewRecord, resolved, actionData)
+	case workspaceViewModePivot:
+		return loadWorkspacePivotData(ctx, viewRecord, resolved, actionData)
 	default:
 		return nil
 	}
@@ -274,6 +276,15 @@ func loadWorkspaceKanbanData(ctx context.Context, viewRecord *render.ViewRecordD
 		viewRecord.KanbanGroupField = groupField
 		viewRecord.KanbanDraggable = draggable
 	}
+	return nil
+}
+
+func loadWorkspacePivotData(ctx context.Context, viewRecord *render.ViewRecordData, resolved *resolvedWorkspaceView, actionData map[string]interface{}) error {
+	rows, err := searchWorkspaceRows(ctx, resolved.targetModel, actionData, maxWorkspaceListRows)
+	if err != nil {
+		return fmt.Errorf("pivot load: %w", err)
+	}
+	viewRecord.Pivot = render.BuildPivotData(resolved.view, rows)
 	return nil
 }
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sumeru_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d sumeru_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 15

--- a/sumeru.conf.example
+++ b/sumeru.conf.example
@@ -44,3 +44,19 @@ log_rolling = false
 # logo_path =
 # company_display_name =
 # user_display_name =
+
+# Database pool (optional — tune for production load)
+# db_max_open_conns = 25
+# db_max_idle_conns = 10
+# db_conn_max_lifetime_minutes = 30
+# db_read_replica_dsn = host=replica dbname=sumeru user=postgres password=postgres sslmode=disable
+
+# Rate limiting (optional; requests per minute per client IP on /api/rpc and /web/login)
+# rate_limit_rpm = 120
+
+# SMTP (optional — password reset and notifications)
+# smtp_host = localhost
+# smtp_port = 587
+# smtp_user =
+# smtp_password =
+# smtp_from = noreply@example.com

--- a/sumeru.conf.example
+++ b/sumeru.conf.example
@@ -13,6 +13,7 @@ db_sslmode = disable
 
 # HTTP (required)
 http_port = 8080
+# http_interface = 127.0.0.1
 dev_mode = true
 
 # Setup wizard — first run only; leave setup_token empty to skip

--- a/test/api/rpc_methods_test.go
+++ b/test/api/rpc_methods_test.go
@@ -1,0 +1,15 @@
+package api_test
+
+import (
+	"testing"
+
+	"sumeru/core/server/api"
+)
+
+func TestPublicMethods_includesReadGroupAndCall(t *testing.T) {
+	for _, m := range []string{"read_group", "call"} {
+		if !api.PublicMethods[m] {
+			t.Fatalf("expected %q in PublicMethods", m)
+		}
+	}
+}

--- a/test/config/http_interface_test.go
+++ b/test/config/http_interface_test.go
@@ -1,0 +1,32 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sumeru/core/server/config"
+)
+
+func TestLoadHTTPInterface(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "sumeru.conf")
+	content := `db_host = localhost
+db_port = 5432
+db_user = u
+db_password = p
+db_name = n
+http_port = 8080
+http_interface = 127.0.0.1
+addons_path = addons
+`
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.LoadConfig(p); err != nil {
+		t.Fatal(err)
+	}
+	if config.AppConfig.HttpInterface != "127.0.0.1" {
+		t.Fatalf("expected 127.0.0.1, got %q", config.AppConfig.HttpInterface)
+	}
+}

--- a/test/integration/db_test.go
+++ b/test/integration/db_test.go
@@ -1,0 +1,28 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"sumeru/core/orm"
+)
+
+func TestIntegrationDBPing(t *testing.T) {
+	dsn := os.Getenv("SUMERU_TEST_DSN")
+	if dsn == "" {
+		t.Skip("SUMERU_TEST_DSN not set")
+	}
+	orm.InitDBWithPool(dsn, orm.DBPoolSettings{MaxOpenConns: 5, MaxIdleConns: 2})
+	if !orm.IsInitialized() {
+		t.Skip("database not initialized (run setup or apply schema first)")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := orm.SearchLimit(ctx, "sys.module", nil, 5); err != nil {
+		t.Fatalf("search sys.module: %v", err)
+	}
+}

--- a/test/orm/computed_test.go
+++ b/test/orm/computed_test.go
@@ -1,0 +1,41 @@
+package orm_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"sumeru/core/orm"
+)
+
+func TestApplyComputes(t *testing.T) {
+	orm.RegisterCompute("test.compute", "full_name", []string{"first", "last"}, func(_ context.Context, rec map[string]interface{}) (interface{}, error) {
+		return orm.AsString(rec["first"]) + " " + orm.AsString(rec["last"]), nil
+	})
+	rec := map[string]interface{}{"first": "Ada", "last": "Lovelace"}
+	if err := orm.ApplyComputes(context.Background(), "test.compute", rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec["full_name"] != "Ada Lovelace" {
+		t.Fatalf("got %q", rec["full_name"])
+	}
+}
+
+func TestMergeDomainsAND(t *testing.T) {
+	base := [][]interface{}{{"active", "=", true}}
+	search := [][]interface{}{{"name", "ilike", "%acme%"}}
+	out := orm.MergeDomains(base, search)
+	if len(out) != 2 {
+		t.Fatalf("len=%d", len(out))
+	}
+}
+
+func TestBuildListSearchDomainOR(t *testing.T) {
+	dom := orm.BuildListSearchDomain("sys.module", []string{"name", "state"}, "base")
+	if len(dom) < 3 {
+		t.Fatalf("expected OR domain, got %v", dom)
+	}
+	if fmt.Sprint(dom[0][0]) != "|" {
+		t.Fatalf("expected leading OR, got %v", dom)
+	}
+}

--- a/test/orm/sql_safety_test.go
+++ b/test/orm/sql_safety_test.go
@@ -65,7 +65,7 @@ func TestBuildWhereWithRecordRules_rejectsBadDomain(t *testing.T) {
 	badDomains := [][][]interface{}{
 		{{"id; DROP", "=", 1}},
 		{{"1=1--", "=", "x"}},
-		{{"name", "LIKE", "%"}},
+		{{"name", "REGEXP", ".*"}},
 		{{"name", "=", "ok", "extra"}},
 	}
 	for _, dom := range badDomains {

--- a/test/render/html_renderer_list_test.go
+++ b/test/render/html_renderer_list_test.go
@@ -12,7 +12,7 @@ import (
 func TestRenderList_rowClickUsesValidOnclickQuotes(t *testing.T) {
 	v := &parser.View{Type: "list", Field: []parser.Field{{Name: "name"}}}
 	rows := []map[string]interface{}{{"id": 1, "name": "Acme"}}
-	html := render.RenderList(context.Background(), v, rows, 12, "3", "tok")
+	html := render.RenderList(context.Background(), v, rows, 12, "3", "tok", "", "/web?action=12&menu_id=3&view_type=list")
 	if !strings.Contains(html, "onclick='window.location.href=") {
 		t.Fatalf("expected row onclick with single-quoted attribute, got: %s", html)
 	}

--- a/test/render/pivot_render_test.go
+++ b/test/render/pivot_render_test.go
@@ -1,0 +1,38 @@
+package render_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"sumeru/core/engine/parser"
+	"sumeru/core/engine/render"
+)
+
+func TestBuildPivotDataAndRender(t *testing.T) {
+	view := &parser.View{
+		Model: "crm.lead",
+		Type:  "pivot",
+		Field: []parser.Field{
+			{Name: "stage", PivotType: "row", Label: "Stage"},
+			{Name: "team_id", PivotType: "col", Label: "Team"},
+			{Name: "expected_revenue", PivotType: "measure", Label: "Revenue"},
+		},
+	}
+	rows := []map[string]interface{}{
+		{"stage": "New", "team_id": 1, "expected_revenue": 100.0},
+		{"stage": "New", "team_id": 1, "expected_revenue": 50.0},
+		{"stage": "Won", "team_id": 2, "expected_revenue": 200.0},
+	}
+	data := render.BuildPivotData(view, rows)
+	if data == nil {
+		t.Fatal("nil pivot data")
+	}
+	if data.Values["New"]["1"] != 150 {
+		t.Fatalf("expected 150 for New/1, got %v", data.Values["New"]["1"])
+	}
+	html := render.RenderPivot(context.Background(), view, data)
+	if !strings.Contains(html, "sum-pivot-table") {
+		t.Fatalf("expected pivot table html, got %q", html)
+	}
+}


### PR DESCRIPTION
## Summary
Merge `dev` into `main` for the Sumeru Go kernel (70 commits).

**Gap-plan platform (latest on dev)**
- JSON-RPC `read_group` and `call` for aggregation and object actions
- `RegisterCompute` on read paths; `ilike` / `like` domain operators
- Versioned SQL migrations (`sumeru-migrate`) on install/update
- Workspace list quick search (`?q=`)
- DB pool INI, optional read replica routing, rate limiting, SMTP password reset
- Multi-instance cron (`SKIP LOCKED`) and outbox → in-process queue
- Dev CLIs: `sumeru-shell`, `sumeru-module`, `sumeru-i18n-import`; `make test-db` / `test-integration`

**Earlier dev work included in this merge**
- Pivot v1, declarative automation, noupdate, outbox drain
- JSON-RPC envelope, object actions, security/CSRF/ACL hardening
- Applog migration off stdlib log; form/workspace UX improvements
- Module install/update pipeline fixes and test layout

## Test plan
- [ ] `go test ./...`
- [ ] `make test-integration` (optional; requires Docker)
- [ ] Smoke: boot server, login, list search, RPC `read_group` / `search_read`
- [ ] Smoke: `-i` / `-u` with migrations on a test module