### PR TITLE
feat: URL actions, workspace iframe, and falsy domain semantics

### DIFF
--- a/core/engine/assets/css/sumeru-workspace.css
+++ b/core/engine/assets/css/sumeru-workspace.css
@@ -1678,3 +1678,17 @@
 .sum-bulk-preview-error {
   color: #c0392b;
 }
+
+.sum-iframe-view {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--sum-topbar-height, 3rem));
+  min-height: 24rem;
+}
+
+.sum-iframe-view__frame {
+  flex: 1 1 auto;
+  width: 100%;
+  border: 0;
+  background: #fff;
+}

--- a/core/engine/parser/module_root_xml.go
+++ b/core/engine/parser/module_root_xml.go
@@ -34,11 +34,23 @@ type Action struct {
 	SearchViewID string `xml:"search_view_id,attr"`
 	Context      string `xml:"context,attr"`
 	Domain   string     `xml:"domain,attr"`
+	URL      string     `xml:"url,attr"`
 	Help     actionHelp `xml:"help"`
 }
 
 // ToRecord converts an Action to a Record for backward compatibility.
 func (a Action) ToRecord() Record {
+	if strings.EqualFold(strings.TrimSpace(a.Type), "url") {
+		fields := []RecordField{
+			{Name: "name", Body: a.Name},
+			{Name: "url", Body: a.URL},
+		}
+		return Record{
+			ID:    a.ID,
+			Model: "sys.action.url",
+			Field: fields,
+		}
+	}
 	fields := []RecordField{
 		{Name: "name", Body: a.Name},
 		{Name: "core_model", Body: a.Model},

--- a/core/engine/render/workspace_url.go
+++ b/core/engine/render/workspace_url.go
@@ -37,6 +37,7 @@ const (
 	ViewModeHierarchy = "hierarchy"
 	ViewModeActivity  = "activity"
 	ViewModeSearch   = "search"
+	ViewModeIframe   = "iframe"
 )
 
 // WorkspaceQuery is the /web workspace query (empty fields are omitted).

--- a/core/engine/swcmeta/types.go
+++ b/core/engine/swcmeta/types.go
@@ -26,6 +26,7 @@ type WorkspacePayload struct {
 	Favorites     []SavedSearchMeta        `json:"favorites,omitempty"`
 	FormBaseQuery string                   `json:"formBaseQuery,omitempty"`
 	Defaults      map[string]interface{}   `json:"defaults,omitempty"`
+	IframeURL     string                   `json:"iframeUrl,omitempty"`
 }
 
 type ViewTab struct {

--- a/core/engine/swcmeta/workspace.go
+++ b/core/engine/swcmeta/workspace.go
@@ -43,6 +43,7 @@ type ViewRecordInput struct {
 	ViewTabs         []ViewTab
 	Breadcrumbs      []Breadcrumb
 	Defaults         map[string]interface{}
+	IframeURL        string
 }
 
 // BuildWorkspacePayload serializes loaded workspace data for SWC.
@@ -102,6 +103,7 @@ func BuildWorkspacePayload(
 		ViewTabs:      rec.ViewTabs,
 		Breadcrumbs:   rec.Breadcrumbs,
 		Defaults:      rec.Defaults,
+		IframeURL:     rec.IframeURL,
 	}
 
 	if selectedMode == listMode || selectedMode == kanbanMode || selectedMode == graphMode || selectedMode == calendarMode || selectedMode == pivotMode || selectedMode == ganttMode || selectedMode == mapMode || selectedMode == cohortMode {
@@ -126,6 +128,26 @@ func BuildWorkspacePayload(
 		payload.ListSections = rec.ListSections
 	}
 	return payload
+}
+
+// BuildIframeWorkspacePayload serializes a URL action for SWC iframe view.
+func BuildIframeWorkspacePayload(actionID int, menuID, iframeURL, title string) WorkspacePayload {
+	iframeURL = strings.TrimSpace(iframeURL)
+	if title == "" {
+		title = "Report"
+	}
+	return WorkspacePayload{
+		ActionID: actionID,
+		MenuID:   menuID,
+		ViewType: "iframe",
+		Model:    "sys.action.url",
+		Arch: ViewArch{
+			Type:  "iframe",
+			Model: "sys.action.url",
+			Title: title,
+		},
+		IframeURL: iframeURL,
+	}
 }
 
 func redactCopy(ctx context.Context, model string, rec map[string]interface{}) map[string]interface{} {

--- a/core/module/data_sync.go
+++ b/core/module/data_sync.go
@@ -19,6 +19,9 @@ func processXMLRecords(ctx context.Context, moduleName string, records []parser.
 		if xmlRecord.Model == "sys.action.window" {
 			upsertSysActionWindowFromRecord(ctx, moduleName, xmlRecord)
 		}
+		if xmlRecord.Model == "sys.action.url" {
+			upsertSysActionURLFromRecord(ctx, moduleName, xmlRecord)
+		}
 		if xmlRecord.Model == "sys.view" {
 			if strings.TrimSpace(parser.RecordFieldMap(xmlRecord)["inherit_id"]) != "" {
 				*inheritQueue = append(*inheritQueue, xmlRecord)

--- a/core/module/data_sync_menus.go
+++ b/core/module/data_sync_menus.go
@@ -21,6 +21,7 @@ func syncMenusFromItems(ctx context.Context, moduleName string, menus []parser.M
 			"access_groups": strings.TrimSpace(menu.AccessGroups),
 		}
 		if menu.Action != "" {
+			menuValues["action"] = menu.Action
 			actionID, err := resolveXMLIDInModule(ctx, moduleName, menu.Action)
 			if err == nil && actionID != 0 {
 				menuValues["action_id"] = actionID

--- a/core/module/data_sync_records.go
+++ b/core/module/data_sync_records.go
@@ -80,7 +80,7 @@ func naturalKeyMoveLine(fieldValues map[string]interface{}) map[string]interface
 }
 
 func syncGenericRegistryRecord(ctx context.Context, moduleName string, xmlRecord parser.Record) {
-	if xmlRecord.Model == "sys.action.window" || xmlRecord.Model == "sys.view" {
+	if xmlRecord.Model == "sys.action.window" || xmlRecord.Model == "sys.action.url" || xmlRecord.Model == "sys.view" {
 		return
 	}
 	modelInstance, ok := orm.Registry[xmlRecord.Model]

--- a/core/module/data_sync_views.go
+++ b/core/module/data_sync_views.go
@@ -41,6 +41,23 @@ func upsertSysActionWindowFromRecord(ctx context.Context, moduleName string, xml
 	_ = linkXMLRecord(ctx, moduleName, xmlRecord.ID, "sys.action.window", id)
 }
 
+func upsertSysActionURLFromRecord(ctx context.Context, moduleName string, xmlRecord parser.Record) {
+	recordValues := recordValuesFromXML(xmlRecord)
+	if u := strings.TrimSpace(orm.AsString(recordValues["url"])); u == "" {
+		syncWarn(ctx, "Warning: sys.action.url record %s (module %s): url is required", xmlRecord.ID, moduleName)
+		return
+	}
+	if _, ok := recordValues["name"]; !ok || recordValues["name"] == "" {
+		recordValues["name"] = xmlRecord.ID
+	}
+	id, err := orm.Upsert(ctx, orm.RegistryModel("sys.action.url"), recordValues, "name")
+	if err != nil {
+		syncWarn(ctx, platformmsg.FmtGenericUpsertWarn, "sys.action.url", xmlRecord.ID, err)
+		return
+	}
+	_ = linkXMLRecord(ctx, moduleName, xmlRecord.ID, "sys.action.url", id)
+}
+
 // upsertSysViewFromRecord persists <record model="sys.view">…</record> data (non-inherit rows).
 // Inline <view> elements use upsertInlineViewDef instead; inherit-only records are handled elsewhere.
 func upsertSysViewFromRecord(ctx context.Context, moduleName string, xmlRecord parser.Record) {

--- a/core/module/install.go
+++ b/core/module/install.go
@@ -215,7 +215,7 @@ func deleteModuleMetadata(ctx context.Context, moduleName string) error {
 		return fmt.Errorf("delete sys.view: %w", err)
 	}
 
-	modelNames := []string{"sys.menu", "sys.action.window", "sys.access", "sys.rule", "sys.approval.rule"}
+	modelNames := []string{"sys.menu", "sys.action.window", "sys.action.url", "sys.access", "sys.rule", "sys.approval.rule"}
 	for _, modelName := range modelNames {
 		tableName, err := orm.QuotedTableName(modelName)
 		if err != nil {

--- a/core/orm/action_lookup.go
+++ b/core/orm/action_lookup.go
@@ -1,0 +1,65 @@
+package orm
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ActionModels lists navigable action tables referenced from sys.menu.action_id.
+var ActionModels = []string{"sys.action.window", "sys.action.url"}
+
+// ResolveActionRecord returns the action model name and core row id for a menu /web link.
+// actionQuery may be a numeric id or an XML id (module.name); actionID is the parsed numeric id when known.
+func ResolveActionRecord(ctx context.Context, actionID int, actionQuery string) (modelName string, coreID int, err error) {
+	actionQuery = strings.TrimSpace(actionQuery)
+	if actionQuery != "" && strings.Contains(actionQuery, ".") {
+		id, model, err := ResolveXmlId(ctx, actionQuery)
+		if err != nil {
+			return "", 0, err
+		}
+		if id <= 0 {
+			return "", 0, fmt.Errorf("action %q not found", actionQuery)
+		}
+		return model, id, nil
+	}
+	if actionID > 0 {
+		return actionModelForCoreID(ctx, actionID)
+	}
+	if actionQuery != "" {
+		if id, err := strconv.Atoi(actionQuery); err == nil && id > 0 {
+			return actionModelForCoreID(ctx, id)
+		}
+	}
+	return "", 0, fmt.Errorf("action not found")
+}
+
+func actionModelForCoreID(ctx context.Context, coreID int) (string, int, error) {
+	if coreID <= 0 {
+		return "", 0, fmt.Errorf("action not found")
+	}
+	rows, err := Search(ctx, "sys.model.data", [][]interface{}{
+		{"core_id", "=", coreID},
+		{"model", "in", actionModelsSlice()},
+	})
+	if err != nil {
+		return "", 0, err
+	}
+	if len(rows) == 0 {
+		return "", 0, fmt.Errorf("action %d not found", coreID)
+	}
+	modelName := strings.TrimSpace(AsString(rows[0]["model"]))
+	if modelName == "" {
+		return "", 0, fmt.Errorf("action %d not found", coreID)
+	}
+	return modelName, coreID, nil
+}
+
+func actionModelsSlice() []interface{} {
+	out := make([]interface{}, len(ActionModels))
+	for i, m := range ActionModels {
+		out[i] = m
+	}
+	return out
+}

--- a/core/orm/crud_domain.go
+++ b/core/orm/crud_domain.go
@@ -155,7 +155,9 @@ func joinShiftedWhereFragments(separator, modelName string, domains [][][]interf
 	return strings.Join(parts, separator), args, nil
 }
 
-// dateLikeNullCheck detects date unset/set domains: ("field", "!=", false) means IS NOT NULL.
+// dateLikeNullCheck detects falsy domain sentinels on nullable non-boolean columns.
+// ("field", "!=", false) → IS NOT NULL; ("field", "=", false) → IS NULL.
+// Applies to Date, DateTime, and Many2One (unset FK stored as NULL).
 func dateLikeNullCheck(modelName, fieldName string, value interface{}) (isSetCheck bool, ok bool) {
 	b, ok := value.(bool)
 	if !ok {
@@ -169,10 +171,12 @@ func dateLikeNullCheck(modelName, fieldName string, value interface{}) (isSetChe
 		if fieldDef.Name != fieldName {
 			continue
 		}
-		if fieldDef.Type != Date && fieldDef.Type != DateTime {
+		switch fieldDef.Type {
+		case Date, DateTime, Many2One:
+			return !b, true
+		default:
 			return false, false
 		}
-		return !b, true
 	}
 	return false, false
 }

--- a/core/orm/crud_domain.go
+++ b/core/orm/crud_domain.go
@@ -33,27 +33,17 @@ func buildSearchWhereClause(modelName string, domain [][]interface{}) (string, [
 			return "", nil, fmt.Errorf("domain field name")
 		}
 		op := strings.TrimSpace(strings.ToLower(fmt.Sprint(clause[1])))
+		if frag, fragArgs, handled, err := buildFalsyDomainClause(modelName, field, op, clause[2]); handled {
+			if err != nil {
+				return "", nil, err
+			}
+			parts = append(parts, frag)
+			args = append(args, fragArgs...)
+			continue
+		}
 		col, err := QuotedColumnForModel(modelName, field)
 		if err != nil {
 			return "", nil, err
-		}
-		if dateLike, isBool := dateLikeNullCheck(modelName, field, clause[2]); isBool {
-			switch op {
-			case "!=":
-				if dateLike {
-					parts = append(parts, fmt.Sprintf("%s IS NOT NULL", col))
-				} else {
-					parts = append(parts, fmt.Sprintf("%s IS NULL", col))
-				}
-				continue
-			case "=":
-				if dateLike {
-					parts = append(parts, fmt.Sprintf("%s IS NULL", col))
-				} else {
-					parts = append(parts, fmt.Sprintf("%s IS NOT NULL", col))
-				}
-				continue
-			}
 		}
 		switch op {
 		case "=":
@@ -153,32 +143,6 @@ func joinShiftedWhereFragments(separator, modelName string, domains [][][]interf
 		placeholderIndex += len(fragmentArgs)
 	}
 	return strings.Join(parts, separator), args, nil
-}
-
-// dateLikeNullCheck detects falsy domain sentinels on nullable non-boolean columns.
-// ("field", "!=", false) → IS NOT NULL; ("field", "=", false) → IS NULL.
-// Applies to Date, DateTime, and Many2One (unset FK stored as NULL).
-func dateLikeNullCheck(modelName, fieldName string, value interface{}) (isSetCheck bool, ok bool) {
-	b, ok := value.(bool)
-	if !ok {
-		return false, false
-	}
-	inst, has := Registry[modelName]
-	if !has || inst == nil {
-		return false, false
-	}
-	for _, fieldDef := range inst.Fields() {
-		if fieldDef.Name != fieldName {
-			continue
-		}
-		switch fieldDef.Type {
-		case Date, DateTime, Many2One:
-			return !b, true
-		default:
-			return false, false
-		}
-	}
-	return false, false
 }
 
 // buildAndWhereClauses ANDs independent domain parts, each compiled separately

--- a/core/orm/domain_json.go
+++ b/core/orm/domain_json.go
@@ -119,14 +119,15 @@ func SubstituteDomainContext(domain [][]interface{}, dc DomainContext) [][]inter
 
 // RecordMatchesDomain evaluates AND of triples for =, !=, in (value list).
 // Prefix Polish "|" markers OR the following leaf triples (same shape as BuildWhereWithRecordRules group OR).
-func RecordMatchesDomain(recordMap map[string]interface{}, domain [][]interface{}) bool {
+// modelName enables field-type-aware falsy domain handling (= false / != false); pass "" to use generic rules.
+func RecordMatchesDomain(modelName string, recordMap map[string]interface{}, domain [][]interface{}) bool {
 	orLeaves, leaves, ok := splitDomainORPrefix(domain)
 	if orLeaves > 0 {
 		if !ok {
 			return false
 		}
 		for _, leaf := range leaves {
-			if RecordMatchesDomain(recordMap, [][]interface{}{leaf}) {
+			if RecordMatchesDomain(modelName, recordMap, [][]interface{}{leaf}) {
 				return true
 			}
 		}
@@ -141,6 +142,14 @@ func RecordMatchesDomain(recordMap map[string]interface{}, domain [][]interface{
 		cellValue, ok := recordMap[fieldName]
 		if !ok {
 			cellValue = nil
+		}
+		if wantBool, isBool := clause[2].(bool); isBool {
+			if matched, handled := cellMatchesFalsy(modelName, fieldName, operator, cellValue, wantBool); handled {
+				if !matched {
+					return false
+				}
+				continue
+			}
 		}
 		switch operator {
 		case "=":

--- a/core/orm/falsy_domain.go
+++ b/core/orm/falsy_domain.go
@@ -1,0 +1,279 @@
+package orm
+
+import (
+	"fmt"
+	"strings"
+)
+
+type falsyKind int
+
+const (
+	falsyNone falsyKind = iota
+	falsyNull
+	falsyEmpty
+	falsyNullOrZero
+	falsyRelOne2Many
+	falsyRelMany2Many
+)
+
+func falsyKindForField(fieldDef FieldDefinition) falsyKind {
+	switch fieldDef.Type {
+	case Date, DateTime, Many2One, Json:
+		return falsyNull
+	case Char, Text, Selection:
+		return falsyEmpty
+	case Integer, Float, Float64, Numeric:
+		return falsyNullOrZero
+	case One2Many:
+		return falsyRelOne2Many
+	case Many2Many:
+		return falsyRelMany2Many
+	default:
+		return falsyNone
+	}
+}
+
+func falsyWantSet(op string, value bool) (bool, bool) {
+	switch strings.TrimSpace(strings.ToLower(op)) {
+	case "=":
+		return value, true
+	case "!=":
+		return !value, true
+	default:
+		return false, false
+	}
+}
+
+func lookupFalsyField(modelName, fieldName string) (FieldDefinition, falsyKind, bool) {
+	inst, ok := Registry[modelName]
+	if !ok || inst == nil {
+		return FieldDefinition{}, falsyNone, false
+	}
+	for _, fieldDef := range inst.Fields() {
+		if fieldDef.Name != fieldName {
+			continue
+		}
+		kind := falsyKindForField(fieldDef)
+		if kind == falsyNone {
+			return fieldDef, falsyNone, false
+		}
+		return fieldDef, kind, true
+	}
+	return FieldDefinition{}, falsyNone, false
+}
+
+func buildFalsyDomainClause(modelName, fieldName, op string, value interface{}) (clause string, args []interface{}, handled bool, err error) {
+	b, ok := value.(bool)
+	if !ok {
+		return "", nil, false, nil
+	}
+	wantSet, ok := falsyWantSet(op, b)
+	if !ok {
+		return "", nil, false, nil
+	}
+	fieldDef, kind, ok := lookupFalsyField(modelName, fieldName)
+	if !ok {
+		return "", nil, false, nil
+	}
+	switch kind {
+	case falsyNull, falsyEmpty, falsyNullOrZero:
+		col, err := QuotedColumnForModel(modelName, fieldName)
+		if err != nil {
+			return "", nil, false, err
+		}
+		return falsyColumnClause(col, kind, wantSet), nil, true, nil
+	case falsyRelOne2Many:
+		clause, err := falsyOne2ManyClause(modelName, fieldDef, wantSet)
+		return clause, nil, true, err
+	case falsyRelMany2Many:
+		clause, err := falsyMany2ManyClause(modelName, fieldDef, wantSet)
+		return clause, nil, true, err
+	default:
+		return "", nil, false, nil
+	}
+}
+
+func falsyColumnClause(col string, kind falsyKind, wantSet bool) string {
+	switch kind {
+	case falsyNull:
+		if wantSet {
+			return col + " IS NOT NULL"
+		}
+		return col + " IS NULL"
+	case falsyEmpty:
+		if wantSet {
+			return fmt.Sprintf("(%s IS NOT NULL AND %s <> '')", col, col)
+		}
+		return fmt.Sprintf("(%s IS NULL OR %s = '')", col, col)
+	case falsyNullOrZero:
+		if wantSet {
+			return fmt.Sprintf("(%s IS NOT NULL AND %s <> 0)", col, col)
+		}
+		return fmt.Sprintf("(%s IS NULL OR %s = 0)", col, col)
+	default:
+		return "TRUE"
+	}
+}
+
+func falsyOne2ManyClause(parentModel string, fieldDef FieldDefinition, wantSet bool) (string, error) {
+	comodel := strings.TrimSpace(fieldDef.Relation)
+	if comodel == "" {
+		return "", fmt.Errorf("one2many field %q on %s missing relation", fieldDef.Name, parentModel)
+	}
+	inverse := ResolveInverseOne2ManyField(parentModel, comodel)
+	if inverse == "" {
+		return "", fmt.Errorf("one2many field %q on %s: no inverse many2one on %s", fieldDef.Name, parentModel, comodel)
+	}
+	parentTbl, err := QuotedTableName(parentModel)
+	if err != nil {
+		return "", err
+	}
+	childTbl, err := QuotedTableForModel(comodel)
+	if err != nil {
+		return "", err
+	}
+	inverseCol, err := QuotedColumnForModel(comodel, inverse)
+	if err != nil {
+		return "", err
+	}
+	parentIDCol := parentTbl + "." + quoteIdent("id")
+	exists := fmt.Sprintf("EXISTS (SELECT 1 FROM %s rel WHERE rel.%s = %s)", childTbl, inverseCol, parentIDCol)
+	if wantSet {
+		return exists, nil
+	}
+	return "NOT " + exists, nil
+}
+
+func falsyMany2ManyClause(parentModel string, fieldDef FieldDefinition, wantSet bool) (string, error) {
+	relTable := strings.TrimSpace(fieldDef.RelationTable)
+	leftCol := strings.TrimSpace(fieldDef.Column1)
+	if relTable == "" || leftCol == "" {
+		return "", fmt.Errorf("many2many field %q on %s missing relation table metadata", fieldDef.Name, parentModel)
+	}
+	if err := ValidateFieldName(relTable); err != nil {
+		return "", err
+	}
+	if err := ValidateFieldName(leftCol); err != nil {
+		return "", err
+	}
+	parentTbl, err := QuotedTableName(parentModel)
+	if err != nil {
+		return "", err
+	}
+	relTbl := quoteIdent(relTable)
+	leftQuoted := quoteIdent(leftCol)
+	parentIDCol := parentTbl + "." + quoteIdent("id")
+	exists := fmt.Sprintf("EXISTS (SELECT 1 FROM %s rel WHERE rel.%s = %s)", relTbl, leftQuoted, parentIDCol)
+	if wantSet {
+		return exists, nil
+	}
+	return "NOT " + exists, nil
+}
+
+func cellIsFalsyEmpty(modelName, fieldName string, cellValue interface{}) bool {
+	if fieldName != "" && modelName != "" {
+		if fieldDef, kind, ok := lookupFalsyField(modelName, fieldName); ok {
+			switch kind {
+			case falsyNull:
+				if cellValue == nil {
+					return true
+				}
+				if id, ok := CoerceInt64(cellValue); ok {
+					return id == 0
+				}
+				return false
+			case falsyEmpty:
+				return cellValue == nil || strings.TrimSpace(AsString(cellValue)) == ""
+			case falsyNullOrZero:
+				if cellValue == nil {
+					return true
+				}
+				if n, ok := CoerceInt64(cellValue); ok {
+					return n == 0
+				}
+				f, ok := toFloat64(cellValue)
+				return ok && f == 0
+			case falsyRelOne2Many, falsyRelMany2Many:
+				return relationalCellEmpty(cellValue)
+			case falsyNone:
+				if fieldDef.Type == Boolean {
+					return !AsBool(cellValue)
+				}
+			}
+		}
+	}
+	return genericCellEmpty(cellValue)
+}
+
+func relationalCellEmpty(cellValue interface{}) bool {
+	switch v := cellValue.(type) {
+	case nil:
+		return true
+	case []interface{}:
+		return len(v) == 0
+	case []int:
+		return len(v) == 0
+	case []int64:
+		return len(v) == 0
+	case []map[string]interface{}:
+		return len(v) == 0
+	default:
+		if id, ok := CoerceInt64(cellValue); ok {
+			return id == 0
+		}
+		return strings.TrimSpace(AsString(cellValue)) == ""
+	}
+}
+
+func genericCellEmpty(cellValue interface{}) bool {
+	if cellValue == nil {
+		return true
+	}
+	if relationalCellEmpty(cellValue) {
+		return true
+	}
+	if s, ok := cellValue.(string); ok {
+		return strings.TrimSpace(s) == ""
+	}
+	if !AsBool(cellValue) {
+		return true
+	}
+	return false
+}
+
+func cellMatchesFalsy(modelName, fieldName, op string, cellValue interface{}, wantBool bool) (matched bool, handled bool) {
+	wantSet, ok := falsyWantSet(op, wantBool)
+	if !ok {
+		return false, false
+	}
+	if modelName != "" && fieldName != "" {
+		if inst, has := Registry[modelName]; has && inst != nil {
+			for _, fieldDef := range inst.Fields() {
+				if fieldDef.Name != fieldName {
+					continue
+				}
+				if fieldDef.Type == Boolean {
+					got := AsBool(cellValue)
+					if strings.TrimSpace(strings.ToLower(op)) == "!=" {
+						return got != wantBool, true
+					}
+					return got == wantBool, true
+				}
+				kind := falsyKindForField(fieldDef)
+				if kind == falsyNone {
+					return false, false
+				}
+				empty := cellIsFalsyEmpty(modelName, fieldName, cellValue)
+				if wantSet {
+					return !empty, true
+				}
+				return empty, true
+			}
+		}
+	}
+	empty := genericCellEmpty(cellValue)
+	if wantSet {
+		return !empty, true
+	}
+	return empty, true
+}

--- a/core/orm/record_rules.go
+++ b/core/orm/record_rules.go
@@ -239,7 +239,7 @@ func CheckRecordRules(ctx context.Context, uid int, model string, op string, rec
 		return err
 	}
 	for _, dom := range parts.globals {
-		if !RecordMatchesDomain(rec, dom) {
+		if !RecordMatchesDomain(model, rec, dom) {
 			return &RecordRuleError{Model: model}
 		}
 	}
@@ -250,7 +250,7 @@ func CheckRecordRules(ctx context.Context, uid int, model string, op string, rec
 		return nil
 	}
 	for _, dom := range parts.groups {
-		if RecordMatchesDomain(rec, dom) {
+		if RecordMatchesDomain(model, rec, dom) {
 			return nil
 		}
 	}

--- a/core/orm/setup_sync.go
+++ b/core/orm/setup_sync.go
@@ -26,6 +26,7 @@ var InitialSetupModelNames = []string{
 	"mail.message",
 	"sys.access",
 	"sys.action.window",
+	"sys.action.url",
 	"sys.approval.rule",
 	"sys.field",
 	"sys.menu",

--- a/core/orm/sys_action_url.go
+++ b/core/orm/sys_action_url.go
@@ -1,0 +1,12 @@
+package orm
+
+import (
+	"sumeru/core/modelmeta"
+)
+
+type SysActionURL struct {
+	modelmeta.ModelMeta `sumeru:"model=sys.action.url"`
+
+	Name modelmeta.String `sumeru:"required,unique"`
+	URL  modelmeta.String `sumeru:"required"`
+}

--- a/core/orm/testexports.go
+++ b/core/orm/testexports.go
@@ -1,6 +1,9 @@
 package orm
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 type StubModelForTest struct {
 	name   string
@@ -41,6 +44,10 @@ func BuildAndWhereClausesForTest(modelName string, groups [][][]interface{}) (st
 
 func RecordMatchesDomainForTest(modelName string, rec map[string]interface{}, domain [][]interface{}) bool {
 	return RecordMatchesDomain(modelName, rec, domain)
+}
+
+func ResolveActionRecordForTest(ctx context.Context, actionID int, actionQuery string) (modelName string, coreID int, err error) {
+	return ResolveActionRecord(ctx, actionID, actionQuery)
 }
 
 // SetDBForTest replaces the global DB handle for external tests. Call ResetDBForTest in t.Cleanup.

--- a/core/orm/testexports.go
+++ b/core/orm/testexports.go
@@ -39,8 +39,8 @@ func BuildAndWhereClausesForTest(modelName string, groups [][][]interface{}) (st
 	return buildAndWhereClauses(modelName, groups)
 }
 
-func RecordMatchesDomainForTest(rec map[string]interface{}, domain [][]interface{}) bool {
-	return RecordMatchesDomain(rec, domain)
+func RecordMatchesDomainForTest(modelName string, rec map[string]interface{}, domain [][]interface{}) bool {
+	return RecordMatchesDomain(modelName, rec, domain)
 }
 
 // SetDBForTest replaces the global DB handle for external tests. Call ResetDBForTest in t.Cleanup.

--- a/core/ormmodels/zmodels.go
+++ b/core/ormmodels/zmodels.go
@@ -11,6 +11,7 @@ func init() {
 	modelreg.MustRegister("base",
 		&orm.AppLog{},
 		&orm.SysAccess{},
+		&orm.SysActionURL{},
 		&orm.SysActionWindow{},
 		&orm.SysApprovalRule{},
 		&orm.SysField{},

--- a/core/server/web/action_resolve.go
+++ b/core/server/web/action_resolve.go
@@ -1,0 +1,50 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sumeru/core/orm"
+)
+
+type navActionKind int
+
+const (
+	navActionUnknown navActionKind = iota
+	navActionWindow
+	navActionURL
+)
+
+type navigationAction struct {
+	kind       navActionKind
+	url        string
+	windowData map[string]interface{}
+}
+
+func resolveNavigationAction(ctx context.Context, actionID int, actionQuery string) (navigationAction, error) {
+	modelName, coreID, err := orm.ResolveActionRecord(ctx, actionID, actionQuery)
+	if err != nil {
+		return navigationAction{}, err
+	}
+	switch modelName {
+	case sysActionURLModel:
+		row, err := orm.SearchOne(ctx, sysActionURLModel, map[string]interface{}{"id": coreID})
+		if err != nil {
+			return navigationAction{}, fmt.Errorf("action %d not found", coreID)
+		}
+		url := strings.TrimSpace(orm.AsString(row["url"]))
+		if url == "" {
+			return navigationAction{}, fmt.Errorf("action %d has empty url", coreID)
+		}
+		return navigationAction{kind: navActionURL, url: url}, nil
+	case sysActionWindowModel:
+		row, err := loadWindowAction(ctx, coreID)
+		if err != nil {
+			return navigationAction{}, fmt.Errorf("action %d not found", coreID)
+		}
+		return navigationAction{kind: navActionWindow, windowData: row}, nil
+	default:
+		return navigationAction{}, fmt.Errorf("unsupported action model %q", modelName)
+	}
+}

--- a/core/server/web/swc_workspace.go
+++ b/core/server/web/swc_workspace.go
@@ -28,6 +28,21 @@ func SwcWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
 	actionID := ResolveWindowActionID(ctx, actionQuery, menuQuery)
 	modelQuery := strings.TrimSpace(r.URL.Query().Get(workspaceModelParam))
 
+	if actionID != 0 || strings.TrimSpace(actionQuery) != "" {
+		nav, navErr := resolveNavigationAction(ctx, actionID, actionQuery)
+		if navErr != nil {
+			respondActionNotFound(w, actionID)
+			return
+		}
+		if nav.kind == navActionURL {
+			req := parseWorkspaceRequest(r, actionID)
+			req.menuID = CanonicalMenuID(ctx, req.menuID, actionID)
+			payload := buildIframeSwcPayload(ctx, actionID, req.menuID, nav.url)
+			writeJSONResponse(w, payload)
+			return
+		}
+	}
+
 	var actionData map[string]interface{}
 	var resolved *resolvedWorkspaceView
 	var err error

--- a/core/server/web/testexports.go
+++ b/core/server/web/testexports.go
@@ -421,3 +421,34 @@ func (h *BusHubForTest) Register(c *SwcBusClientForTest) { h.hub.register(c.clie
 func (h *BusHubForTest) Broadcast(actor int, msg []byte) { h.hub.broadcast(actor, msg) }
 
 func (c *SwcBusClientForTest) Recv() <-chan []byte { return c.client.send }
+
+func BuildIframeSwcPayloadForTest(ctx context.Context, actionID int, menuID, iframeURL string) map[string]interface{} {
+	p := buildIframeSwcPayload(ctx, actionID, menuID, iframeURL)
+	return map[string]interface{}{
+		"viewType":  p.ViewType,
+		"model":     p.Model,
+		"iframeUrl": p.IframeURL,
+		"actionId":  p.ActionID,
+		"menuId":    p.MenuID,
+	}
+}
+
+const (
+	NavActionURLForTest    = navActionURL
+	NavActionWindowForTest = navActionWindow
+)
+
+func ResolveNavigationActionForTest(ctx context.Context, actionID int, actionQuery string) (kind int, url string, err error) {
+	nav, err := resolveNavigationAction(ctx, actionID, actionQuery)
+	if err != nil {
+		return 0, "", err
+	}
+	switch nav.kind {
+	case navActionURL:
+		return int(navActionURL), nav.url, nil
+	case navActionWindow:
+		return int(navActionWindow), "", nil
+	default:
+		return 0, "", err
+	}
+}

--- a/core/server/web/web_constants.go
+++ b/core/server/web/web_constants.go
@@ -221,6 +221,7 @@ const (
 	workspaceViewModeCohort   = render.ViewModeCohort
 	workspaceViewModeHierarchy = render.ViewModeHierarchy
 	workspaceViewModeActivity  = render.ViewModeActivity
+	workspaceViewModeIframe    = render.ViewModeIframe
 	maxWorkspaceListRows      = 500
 	maxWorkspaceKanbanRows    = 200
 	workspaceListPageSize     = 40
@@ -229,6 +230,7 @@ const (
 // ORM models used by workspace handlers.
 const (
 	sysActionWindowModel = "sys.action.window"
+	sysActionURLModel      = "sys.action.url"
 	workspaceViewOpenOp  = "view_open"
 )
 

--- a/core/server/web/workspace.go
+++ b/core/server/web/workspace.go
@@ -30,12 +30,17 @@ func WebHandler(w http.ResponseWriter, r *http.Request) {
 	var actionData map[string]interface{}
 	var resolved *resolvedWorkspaceView
 	var err error
-	if actionID != 0 {
-		actionData, err = loadWindowAction(ctx, actionID)
-		if err != nil {
+	if actionID != 0 || strings.TrimSpace(actionQuery) != "" {
+		nav, navErr := resolveNavigationAction(ctx, actionID, actionQuery)
+		if navErr != nil {
 			respondActionNotFound(w, actionID)
 			return
 		}
+		if nav.kind == navActionURL {
+			renderURLActionWorkspace(w, r, actionID, menuQuery, nav.url)
+			return
+		}
+		actionData = nav.windowData
 		resolved, err = resolveWorkspaceView(ctx, r, actionData)
 	} else if modelQuery != "" {
 		actionData = map[string]interface{}{}

--- a/core/server/web/workspace_iframe.go
+++ b/core/server/web/workspace_iframe.go
@@ -1,0 +1,54 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"sumeru/core/engine/parser"
+	"sumeru/core/engine/render"
+	"sumeru/core/engine/swcmeta"
+	"sumeru/core/orm"
+	"sumeru/core/server/config"
+)
+
+func renderURLActionWorkspace(w http.ResponseWriter, r *http.Request, actionID int, menuQuery, iframeURL string) {
+	ctx := r.Context()
+	menuID := CanonicalMenuID(ctx, menuQuery, actionID)
+	title := urlActionTitle(ctx, actionID)
+	syntheticView := &parser.View{
+		Model: "sys.action.url",
+		Type:  render.ViewModeIframe,
+		Title: title,
+	}
+	recData := &render.ViewRecordData{
+		ActionID: actionID,
+		ResModel: "sys.action.url",
+	}
+	html := render.RenderSWCWorkspace(ctx, render.SWCPageInput{
+		View:         syntheticView,
+		ActiveMenuID: menuID,
+		TemplatesDir: config.AppConfig.TemplatesPath,
+		RecData:      recData,
+		SelectedMode: render.ViewModeIframe,
+	})
+	writeHTML(w, ctx, r.URL.Path, html)
+}
+
+func buildIframeSwcPayload(ctx context.Context, actionID int, menuID, iframeURL string) swcmeta.WorkspacePayload {
+	return swcmeta.BuildIframeWorkspacePayload(actionID, menuID, iframeURL, urlActionTitle(ctx, actionID))
+}
+
+func urlActionTitle(ctx context.Context, actionID int) string {
+	if actionID <= 0 {
+		return "Report"
+	}
+	row, err := orm.SearchOne(ctx, sysActionURLModel, map[string]interface{}{"id": actionID})
+	if err != nil {
+		return "Report"
+	}
+	if name := strings.TrimSpace(orm.AsString(row["name"])); name != "" {
+		return name
+	}
+	return "Report"
+}

--- a/core/swc/src/main.ts
+++ b/core/swc/src/main.ts
@@ -26,6 +26,7 @@ import { MapView } from "./views/map/MapView.js";
 import { CohortView } from "./views/cohort/CohortView.js";
 import { HierarchyView } from "./views/hierarchy/HierarchyView.js";
 import { ActivityView } from "./views/activity/ActivityView.js";
+import { IframeView } from "./views/iframe/IframeView.js";
 import { loadTranslations } from "./i18n/translate.js";
 import { mountDebugPanel } from "./devtools/debug.js";
 import { initDevtoolsBridge } from "./devtools/bridge.js";
@@ -42,6 +43,7 @@ const VIEW_CONSTRUCTORS = {
   cohort: CohortView,
   hierarchy: HierarchyView,
   activity: ActivityView,
+  iframe: IframeView,
 } satisfies Record<string, ViewConstructor>;
 
 function registerCore(): void {

--- a/core/swc/src/types/workspace.ts
+++ b/core/swc/src/types/workspace.ts
@@ -257,4 +257,5 @@ export interface SwcWorkspacePayload {
   favorites?: SwcSavedSearch[];
   formBaseQuery?: string;
   defaults?: Record<string, unknown>;
+  iframeUrl?: string;
 }

--- a/core/swc/src/views/iframe/IframeView.ts
+++ b/core/swc/src/views/iframe/IframeView.ts
@@ -1,0 +1,31 @@
+import { SwcComponent } from "../../runtime/component.js";
+import { html } from "../../template/html.js";
+import type { SwcWorkspacePayload } from "../../types/workspace.js";
+
+/** Embeds a sys.action.url target inside workspace chrome. */
+export class IframeView extends SwcComponent {
+  private src = "";
+
+  override setup(): void {
+    this.syncSrc(this.props.payload as SwcWorkspacePayload);
+  }
+
+  override onPropsChanged(): void {
+    this.syncSrc(this.props.payload as SwcWorkspacePayload);
+  }
+
+  private syncSrc(payload: SwcWorkspacePayload): void {
+    this.src = (payload.iframeUrl ?? "").trim();
+  }
+
+  override template() {
+    if (!this.src) {
+      return html`<div class="sum-flash sum-flash--error">Missing iframe URL</div>`;
+    }
+    return html`
+      <div class="sum-iframe-view">
+        <iframe class="sum-iframe-view__frame" src="${this.src}" title="Embedded content"></iframe>
+      </div>
+    `;
+  }
+}

--- a/core/swc/src/views/iframe/IframeView.ts
+++ b/core/swc/src/views/iframe/IframeView.ts
@@ -2,16 +2,20 @@ import { SwcComponent } from "../../runtime/component.js";
 import { html } from "../../template/html.js";
 import type { SwcWorkspacePayload } from "../../types/workspace.js";
 
+interface IframeViewProps {
+  payload: SwcWorkspacePayload;
+}
+
 /** Embeds a sys.action.url target inside workspace chrome. */
-export class IframeView extends SwcComponent {
+export class IframeView extends SwcComponent<IframeViewProps> {
   private src = "";
 
   override setup(): void {
-    this.syncSrc(this.props.payload as SwcWorkspacePayload);
+    this.syncSrc(this.props.payload);
   }
 
   override onPropsChanged(): void {
-    this.syncSrc(this.props.payload as SwcWorkspacePayload);
+    this.syncSrc(this.props.payload);
   }
 
   private syncSrc(payload: SwcWorkspacePayload): void {

--- a/core/swc/tests/views/view-shells.test.ts
+++ b/core/swc/tests/views/view-shells.test.ts
@@ -2,10 +2,42 @@ import { describe, expect, it, vi } from "vitest";
 import { ActivityView } from "../../src/views/activity/ActivityView.js";
 import { CalendarView } from "../../src/views/calendar/CalendarView.js";
 import { HierarchyView } from "../../src/views/hierarchy/HierarchyView.js";
+import { IframeView } from "../../src/views/iframe/IframeView.js";
 import { PivotView } from "../../src/views/pivot/PivotView.js";
 import { collectionEnv, viewPayload } from "../harness/view.js";
 
 describe("view shells", () => {
+  it("IframeView embeds src from payload", () => {
+    const payload = viewPayload({ type: "iframe" }, []);
+    payload.viewType = "iframe";
+    payload.iframeUrl = "/account/reports/view?type=profit_loss";
+    const view = new IframeView({ payload }, collectionEnv());
+    view.callSetup();
+    const frame = view.render().querySelector("iframe") as HTMLIFrameElement;
+    expect(frame?.getAttribute("src")).toBe("/account/reports/view?type=profit_loss");
+    view.destroy();
+  });
+
+  it("IframeView shows error when iframeUrl missing", () => {
+    const view = new IframeView({ payload: viewPayload({ type: "iframe" }, []) }, collectionEnv());
+    view.callSetup();
+    expect(view.render().textContent).toContain("Missing iframe URL");
+    view.destroy();
+  });
+
+  it("IframeView updates src when payload changes", () => {
+    const payload = viewPayload({ type: "iframe" }, []);
+    payload.iframeUrl = "/a";
+    const view = new IframeView({ payload }, collectionEnv());
+    view.callSetup();
+    expect(view.render().querySelector("iframe")?.getAttribute("src")).toBe("/a");
+    const next = viewPayload({ type: "iframe" }, []);
+    next.iframeUrl = "/b";
+    view.updateProps({ payload: next });
+    expect(view.render().querySelector("iframe")?.getAttribute("src")).toBe("/b");
+    view.destroy();
+  });
+
   it("ActivityView renders list table rows", () => {
     const view = new ActivityView(
       {

--- a/test/acceptance/checks.go
+++ b/test/acceptance/checks.go
@@ -38,7 +38,7 @@ func templatePDFGenerates() bool {
 }
 
 func recordRuleDomainCompiles() bool {
-	return orm.RecordMatchesDomain(map[string]interface{}{"active": true}, [][]interface{}{{"active", "=", true}})
+	return orm.RecordMatchesDomain("", map[string]interface{}{"active": true}, [][]interface{}{{"active", "=", true}})
 }
 
 func fieldAccessModelRegistered() bool {
@@ -79,7 +79,7 @@ func xpathHasClassSupported() bool {
 
 func domainOperatorsSupported() bool {
 	domain := [][]interface{}{{"id", "in", []interface{}{1, 2, 3}}}
-	return orm.RecordMatchesDomain(map[string]interface{}{"id": 2}, domain)
+	return orm.RecordMatchesDomain("", map[string]interface{}{"id": 2}, domain)
 }
 
 func savedSearchModelExists() bool {

--- a/test/core/coverage/exports_test.go
+++ b/test/core/coverage/exports_test.go
@@ -282,7 +282,7 @@ func TestForTestExports_orm(t *testing.T) {
 		t.Fatalf("BuildAndWhereClausesForTest: err=%v", err)
 	}
 	_ = args
-	if !orm.RecordMatchesDomainForTest(map[string]interface{}{"name": "a"}, [][]interface{}{{"name", "=", "a"}}) {
+	if !orm.RecordMatchesDomainForTest("", map[string]interface{}{"name": "a"}, [][]interface{}{{"name", "=", "a"}}) {
 		t.Fatal("RecordMatchesDomainForTest")
 	}
 	stub := orm.NewStubModelForTest("test.stub.only", nil)

--- a/test/core/engine/parser/module_root_xml_test.go
+++ b/test/core/engine/parser/module_root_xml_test.go
@@ -96,3 +96,40 @@ func TestActionSearchViewIDInContext(t *testing.T) {
 		t.Fatalf("context missing search_view_id or default_type: %q", ctx)
 	}
 }
+
+func TestActionURLTypeToRecord(t *testing.T) {
+	in := []byte(`<sumeru><data>
+		<action id="action_report_pl" type="url" name="Profit &amp; Loss"
+			url="/account/reports/view?type=profit_loss"/>
+	</data></sumeru>`)
+	var vl parser.ViewList
+	if err := xml.Unmarshal(in, &vl); err != nil {
+		t.Fatal(err)
+	}
+	vl.MergeViewListData()
+	if len(vl.Actions) != 1 {
+		t.Fatalf("actions=%d", len(vl.Actions))
+	}
+	rec := vl.Actions[0].ToRecord()
+	if rec.Model != "sys.action.url" || rec.ID != "action_report_pl" {
+		t.Fatalf("record: %+v", rec)
+	}
+	var name, url string
+	for _, f := range rec.Field {
+		switch f.Name {
+		case "name":
+			name = f.Body
+		case "url":
+			url = f.Body
+		}
+	}
+	if name != "Profit & Loss" {
+		t.Fatalf("name=%q", name)
+	}
+	if url != "/account/reports/view?type=profit_loss" {
+		t.Fatalf("url=%q", url)
+	}
+	if len(vl.Records) != 1 || vl.Records[0].Model != "sys.action.url" {
+		t.Fatalf("merged records: %+v", vl.Records)
+	}
+}

--- a/test/core/engine/swcmeta/types_sync_test.go
+++ b/test/core/engine/swcmeta/types_sync_test.go
@@ -12,7 +12,7 @@ func TestWorkspacePayloadJSONFieldsContract(t *testing.T) {
 		"actionId", "menuId", "viewType", "model", "recordId", "formEdit", "csrfToken",
 		"arch", "record", "records", "viewTabs", "breadcrumbs", "listSearch", "listSearchUrl",
 		"listTotal", "listSort", "listOffset", "listFilter", "listDomain", "listGroupBy",
-		"listSections", "favorites", "formBaseQuery", "defaults",
+		"listSections", "favorites", "formBaseQuery", "defaults", "iframeUrl",
 	}
 	typ := swcmeta.WorkspacePayloadTypeForTest()
 	got := make([]string, 0, typ.NumField())

--- a/test/core/orm/action_lookup_test.go
+++ b/test/core/orm/action_lookup_test.go
@@ -1,0 +1,55 @@
+package orm_test
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"sumeru/core/orm"
+)
+
+func TestResolveActionRecord_numericURLAction(t *testing.T) {
+	mock := setupMockORM(t)
+	orm.RegisterStubModelForTest(t, "sys.model.data", []orm.FieldDefinition{
+		{Name: "module", Type: orm.Char},
+		{Name: "name", Type: orm.Char},
+		{Name: "model", Type: orm.Char},
+		{Name: "core_id", Type: orm.Integer},
+	})
+	rows := sqlmock.NewRows([]string{"id", "module", "name", "model", "core_id"}).
+		AddRow(1, "account", "action_report_pl", "sys.action.url", 42)
+	mock.ExpectQuery(`SELECT \* FROM "sys_model_data" WHERE \("core_id" = \$1 AND "model" IN \(\$2,\$3\)\)`).
+		WithArgs(42, "sys.action.window", "sys.action.url").
+		WillReturnRows(rows)
+
+	modelName, coreID, err := orm.ResolveActionRecordForTest(bypassCtx(), 42, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modelName != "sys.action.url" || coreID != 42 {
+		t.Fatalf("got model=%q id=%d", modelName, coreID)
+	}
+}
+
+func TestResolveActionRecord_xmlID(t *testing.T) {
+	mock := setupMockORM(t)
+	orm.RegisterStubModelForTest(t, "sys.model.data", []orm.FieldDefinition{
+		{Name: "module", Type: orm.Char},
+		{Name: "name", Type: orm.Char},
+		{Name: "model", Type: orm.Char},
+		{Name: "core_id", Type: orm.Integer},
+	})
+	rows := sqlmock.NewRows([]string{"id", "module", "name", "model", "core_id"}).
+		AddRow(1, "account", "action_report_pl", "sys.action.url", 7)
+	mock.ExpectQuery(`SELECT \* FROM "sys_model_data" WHERE \("module" = \$1 AND "name" = \$2\) LIMIT 1`).
+		WithArgs("account", "action_report_pl").
+		WillReturnRows(rows)
+
+	modelName, coreID, err := orm.ResolveActionRecordForTest(bypassCtx(), 0, "account.action_report_pl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modelName != "sys.action.url" || coreID != 7 {
+		t.Fatalf("got model=%q id=%d", modelName, coreID)
+	}
+}

--- a/test/core/orm/crud_domain_test.go
+++ b/test/core/orm/crud_domain_test.go
@@ -46,6 +46,44 @@ func TestBuildSearchWhereClauseDateEqualsFalseIsNull(t *testing.T) {
 	}
 }
 
+func TestBuildSearchWhereClauseMany2OneNotFalseIsNotNull(t *testing.T) {
+	orm.RegisterStubModelForTest(t, "test.m2o.domain", []orm.FieldDefinition{
+		{Name: "team_id", Type: orm.Many2One, Relation: "crm.team"},
+	})
+
+	where, args, err := orm.BuildSearchWhereClauseForTest("test.m2o.domain", [][]interface{}{
+		{"team_id", "!=", false},
+	})
+	if err != nil {
+		t.Fatalf("buildSearchWhereClause: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+	if where == "" || !strings.Contains(where, "IS NOT NULL") {
+		t.Fatalf("expected IS NOT NULL, got %q", where)
+	}
+}
+
+func TestBuildSearchWhereClauseMany2OneEqualsFalseIsNull(t *testing.T) {
+	orm.RegisterStubModelForTest(t, "test.m2o.domain.eq", []orm.FieldDefinition{
+		{Name: "company_id", Type: orm.Many2One, Relation: "core.company"},
+	})
+
+	where, args, err := orm.BuildSearchWhereClauseForTest("test.m2o.domain.eq", [][]interface{}{
+		{"company_id", "=", false},
+	})
+	if err != nil {
+		t.Fatalf("buildSearchWhereClause: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+	if where == "" || !strings.Contains(where, "IS NULL") {
+		t.Fatalf("expected IS NULL, got %q", where)
+	}
+}
+
 func TestBuildSearchWhereClauseNonDateFalseUsesDistinctFrom(t *testing.T) {
 	orm.RegisterStubModelForTest(t, "test.bool.domain", []orm.FieldDefinition{
 		{Name: "active", Type: orm.Boolean},

--- a/test/core/orm/crud_domain_test.go
+++ b/test/core/orm/crud_domain_test.go
@@ -84,6 +84,139 @@ func TestBuildSearchWhereClauseMany2OneEqualsFalseIsNull(t *testing.T) {
 	}
 }
 
+func TestBuildSearchWhereClauseTextEqualsFalseIsEmpty(t *testing.T) {
+	orm.RegisterStubModelForTest(t, "test.text.domain", []orm.FieldDefinition{
+		{Name: "note", Type: orm.Text},
+	})
+
+	where, args, err := orm.BuildSearchWhereClauseForTest("test.text.domain", [][]interface{}{
+		{"note", "=", false},
+	})
+	if err != nil {
+		t.Fatalf("buildSearchWhereClause: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+	if !strings.Contains(where, "IS NULL") || !strings.Contains(where, "= ''") {
+		t.Fatalf("expected empty text clause, got %q", where)
+	}
+}
+
+func TestBuildSearchWhereClauseSelectionNotFalseIsSet(t *testing.T) {
+	orm.RegisterStubModelForTest(t, "test.selection.domain", []orm.FieldDefinition{
+		{Name: "state", Type: orm.Selection},
+	})
+
+	where, args, err := orm.BuildSearchWhereClauseForTest("test.selection.domain", [][]interface{}{
+		{"state", "!=", false},
+	})
+	if err != nil {
+		t.Fatalf("buildSearchWhereClause: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+	if !strings.Contains(where, "IS NOT NULL") || !strings.Contains(where, "<> ''") {
+		t.Fatalf("expected set selection clause, got %q", where)
+	}
+}
+
+func TestBuildSearchWhereClauseIntegerEqualsFalseIsNullOrZero(t *testing.T) {
+	orm.RegisterStubModelForTest(t, "test.int.domain", []orm.FieldDefinition{
+		{Name: "color", Type: orm.Integer},
+	})
+
+	where, args, err := orm.BuildSearchWhereClauseForTest("test.int.domain", [][]interface{}{
+		{"color", "=", false},
+	})
+	if err != nil {
+		t.Fatalf("buildSearchWhereClause: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+	if !strings.Contains(where, "IS NULL") || !strings.Contains(where, "= 0") {
+		t.Fatalf("expected null-or-zero clause, got %q", where)
+	}
+}
+
+func TestBuildSearchWhereClauseOne2ManyNotFalseUsesExists(t *testing.T) {
+	orm.RegisterStubModelForTest(t, "test.child.domain", []orm.FieldDefinition{
+		{Name: "parent_id", Type: orm.Many2One, Relation: "test.parent.domain"},
+	})
+	orm.RegisterStubModelForTest(t, "test.parent.domain", []orm.FieldDefinition{
+		{Name: "line_ids", Type: orm.One2Many, Relation: "test.child.domain"},
+	})
+
+	where, args, err := orm.BuildSearchWhereClauseForTest("test.parent.domain", [][]interface{}{
+		{"line_ids", "!=", false},
+	})
+	if err != nil {
+		t.Fatalf("buildSearchWhereClause: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+	if !strings.Contains(where, "EXISTS") || !strings.Contains(where, "parent_id") {
+		t.Fatalf("expected EXISTS on inverse many2one, got %q", where)
+	}
+}
+
+func TestBuildSearchWhereClauseMany2ManyEqualsFalseUsesNotExists(t *testing.T) {
+	orm.RegisterStubModelForTest(t, "test.m2m.domain", []orm.FieldDefinition{
+		{Name: "tag_ids", Type: orm.Many2Many, Relation: "test.tag.domain", RelationTable: "test_m2m_rel", Column1: "parent_id", Column2: "tag_id"},
+	})
+
+	where, args, err := orm.BuildSearchWhereClauseForTest("test.m2m.domain", [][]interface{}{
+		{"tag_ids", "=", false},
+	})
+	if err != nil {
+		t.Fatalf("buildSearchWhereClause: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %v", args)
+	}
+	if !strings.Contains(where, "NOT EXISTS") || !strings.Contains(where, "test_m2m_rel") {
+		t.Fatalf("expected NOT EXISTS on rel table, got %q", where)
+	}
+}
+
+func TestRecordMatchesDomainFalsyMany2One(t *testing.T) {
+	model := "test.falsy.m2o"
+	orm.RegisterStubModelForTest(t, model, []orm.FieldDefinition{
+		{Name: "team_id", Type: orm.Many2One, Relation: "crm.team"},
+	})
+
+	if !orm.RecordMatchesDomainForTest(model, map[string]interface{}{"team_id": int64(3)}, [][]interface{}{{"team_id", "!=", false}}) {
+		t.Fatal("expected set many2one to match != false")
+	}
+	if orm.RecordMatchesDomainForTest(model, map[string]interface{}{"team_id": nil}, [][]interface{}{{"team_id", "!=", false}}) {
+		t.Fatal("expected unset many2one to fail != false")
+	}
+	if !orm.RecordMatchesDomainForTest(model, map[string]interface{}{"team_id": nil}, [][]interface{}{{"team_id", "=", false}}) {
+		t.Fatal("expected unset many2one to match = false")
+	}
+}
+
+func TestRecordMatchesDomainFalsyTextAndBoolean(t *testing.T) {
+	model := "test.falsy.text"
+	orm.RegisterStubModelForTest(t, model, []orm.FieldDefinition{
+		{Name: "name", Type: orm.Char},
+		{Name: "active", Type: orm.Boolean},
+	})
+
+	if !orm.RecordMatchesDomainForTest(model, map[string]interface{}{"name": ""}, [][]interface{}{{"name", "=", false}}) {
+		t.Fatal("expected empty char to match = false")
+	}
+	if orm.RecordMatchesDomainForTest(model, map[string]interface{}{"active": false}, [][]interface{}{{"active", "!=", false}}) {
+		t.Fatal("boolean != false should require true")
+	}
+	if !orm.RecordMatchesDomainForTest(model, map[string]interface{}{"active": true}, [][]interface{}{{"active", "!=", false}}) {
+		t.Fatal("boolean != false should match true")
+	}
+}
+
 func TestBuildSearchWhereClauseNonDateFalseUsesDistinctFrom(t *testing.T) {
 	orm.RegisterStubModelForTest(t, "test.bool.domain", []orm.FieldDefinition{
 		{Name: "active", Type: orm.Boolean},
@@ -215,13 +348,13 @@ func TestRecordMatchesDomainORPrefix(t *testing.T) {
 		{"name", "=", "a"},
 		{"name", "=", "b"},
 	}
-	if !orm.RecordMatchesDomainForTest(map[string]interface{}{"name": "a"}, domain) {
+	if !orm.RecordMatchesDomainForTest("", map[string]interface{}{"name": "a"}, domain) {
 		t.Fatal("expected match on first leaf")
 	}
-	if !orm.RecordMatchesDomainForTest(map[string]interface{}{"name": "b"}, domain) {
+	if !orm.RecordMatchesDomainForTest("", map[string]interface{}{"name": "b"}, domain) {
 		t.Fatal("expected match on second leaf")
 	}
-	if orm.RecordMatchesDomainForTest(map[string]interface{}{"name": "c"}, domain) {
+	if orm.RecordMatchesDomainForTest("", map[string]interface{}{"name": "c"}, domain) {
 		t.Fatal("expected no match")
 	}
 }

--- a/test/core/orm/orm_extended_test.go
+++ b/test/core/orm/orm_extended_test.go
@@ -171,7 +171,7 @@ func TestRecordMatchesDomainExtended(t *testing.T) {
 		{"state", "!=", "done"},
 		{"state", "in", []interface{}{"draft", "open"}},
 	}
-	if !orm.RecordMatchesDomainForTest(rec, domain) {
+	if !orm.RecordMatchesDomainForTest("", rec, domain) {
 		t.Fatal("expected match")
 	}
 	orDomain := [][]interface{}{
@@ -179,7 +179,7 @@ func TestRecordMatchesDomainExtended(t *testing.T) {
 		{"state", "=", "done"},
 		{"state", "=", "draft"},
 	}
-	if !orm.RecordMatchesDomainForTest(rec, orDomain) {
+	if !orm.RecordMatchesDomainForTest("", rec, orDomain) {
 		t.Fatal("OR domain")
 	}
 }

--- a/test/core/orm/platform_unit_test.go
+++ b/test/core/orm/platform_unit_test.go
@@ -59,13 +59,13 @@ func TestSubstituteDomainContext_ABAC(t *testing.T) {
 
 func TestRecordMatchesDomain(t *testing.T) {
 	rec := map[string]interface{}{"state": "draft", "user_id": int64(1)}
-	if !orm.RecordMatchesDomain(rec, [][]interface{}{{"state", "=", "draft"}}) {
+	if !orm.RecordMatchesDomain("", rec, [][]interface{}{{"state", "=", "draft"}}) {
 		t.Fatal("expected match")
 	}
-	if orm.RecordMatchesDomain(rec, [][]interface{}{{"state", "=", "done"}}) {
+	if orm.RecordMatchesDomain("", rec, [][]interface{}{{"state", "=", "done"}}) {
 		t.Fatal("expected no match")
 	}
-	if !orm.RecordMatchesDomain(rec, [][]interface{}{{"user_id", "in", []interface{}{int64(1), int64(2)}}}) {
+	if !orm.RecordMatchesDomain("", rec, [][]interface{}{{"user_id", "in", []interface{}{int64(1), int64(2)}}}) {
 		t.Fatal("expected in match")
 	}
 }

--- a/test/core/server/web/action_resolve_test.go
+++ b/test/core/server/web/action_resolve_test.go
@@ -1,0 +1,104 @@
+package web_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"sumeru/core/orm"
+	"sumeru/core/server/web"
+)
+
+func setupURLActionWebTest(t *testing.T) sqlmock.Sqlmock {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orm.SetDBForTest(orm.NewDBWrapper(db))
+	t.Cleanup(func() {
+		_ = db.Close()
+		orm.ResetDBForTest()
+	})
+	orm.RegisterStubModelForTest(t, "sys.model.data", []orm.FieldDefinition{
+		{Name: "module", Type: orm.Char},
+		{Name: "name", Type: orm.Char},
+		{Name: "model", Type: orm.Char},
+		{Name: "core_id", Type: orm.Integer},
+	})
+	orm.RegisterStubModelForTest(t, "sys.action.url", []orm.FieldDefinition{
+		{Name: "name", Type: orm.Char},
+		{Name: "url", Type: orm.Char},
+	})
+	return mock
+}
+
+func bypassCtx() context.Context {
+	return orm.ContextWithBypass(context.Background(), true)
+}
+
+func TestResolveNavigationActionURLRedirect(t *testing.T) {
+	mock := setupURLActionWebTest(t)
+	metaRows := sqlmock.NewRows([]string{"id", "module", "name", "model", "core_id"}).
+		AddRow(1, "account", "x", "sys.action.url", 5)
+	mock.ExpectQuery(`SELECT \* FROM "sys_model_data" WHERE \("core_id" = \$1 AND "model" IN \(\$2,\$3\)\)`).
+		WithArgs(5, "sys.action.window", "sys.action.url").
+		WillReturnRows(metaRows)
+	urlRows := sqlmock.NewRows([]string{"id", "name", "url"}).
+		AddRow(5, "Profit & Loss", "/account/reports/view?type=profit_loss")
+	mock.ExpectQuery(`SELECT \* FROM "sys_action_url" WHERE \("id" = \$1\) LIMIT 1`).
+		WithArgs(5).
+		WillReturnRows(urlRows)
+
+	kind, url, err := web.ResolveNavigationActionForTest(bypassCtx(), 5, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind != int(web.NavActionURLForTest) {
+		t.Fatalf("kind=%d want url", kind)
+	}
+	if url != "/account/reports/view?type=profit_loss" {
+		t.Fatalf("url=%q", url)
+	}
+}
+
+func TestResolveNavigationActionWindowUnchanged(t *testing.T) {
+	mock := setupURLActionWebTest(t)
+	orm.RegisterStubModelForTest(t, "sys.action.window", []orm.FieldDefinition{
+		{Name: "name", Type: orm.Char},
+		{Name: "core_model", Type: orm.Char},
+		{Name: "view_mode", Type: orm.Char},
+	})
+	metaRows := sqlmock.NewRows([]string{"id", "module", "name", "model", "core_id"}).
+		AddRow(1, "base", "x", "sys.action.window", 3)
+	mock.ExpectQuery(`SELECT \* FROM "sys_model_data" WHERE \("core_id" = \$1 AND "model" IN \(\$2,\$3\)\)`).
+		WithArgs(3, "sys.action.window", "sys.action.url").
+		WillReturnRows(metaRows)
+	windowRows := sqlmock.NewRows([]string{"id", "name", "core_model", "view_mode"}).
+		AddRow(3, "Contacts", "core.partner", "list,form")
+	mock.ExpectQuery(`SELECT \* FROM "sys_action_window" WHERE \("id" = \$1\) LIMIT 1`).
+		WithArgs(3).
+		WillReturnRows(windowRows)
+
+	kind, url, err := web.ResolveNavigationActionForTest(bypassCtx(), 3, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind != int(web.NavActionWindowForTest) || url != "" {
+		t.Fatalf("kind=%d url=%q", kind, url)
+	}
+}
+
+func TestBuildIframeSwcPayload(t *testing.T) {
+	got := web.BuildIframeSwcPayloadForTest(bypassCtx(), 9, "12", "/account/reports/view?type=profit_loss")
+	if got["viewType"] != "iframe" {
+		t.Fatalf("viewType=%v", got["viewType"])
+	}
+	if got["iframeUrl"] != "/account/reports/view?type=profit_loss" {
+		t.Fatalf("iframeUrl=%v", got["iframeUrl"])
+	}
+	if got["model"] != "sys.action.url" {
+		t.Fatalf("model=%v", got["model"])
+	}
+}

--- a/test/module/static/account_url_actions_test.go
+++ b/test/module/static/account_url_actions_test.go
@@ -1,0 +1,96 @@
+package static_test
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sumeru/core/engine/parser"
+	"sumeru/test/harness"
+)
+
+func TestAccountReportActionsAreURLActions(t *testing.T) {
+	root := harness.RepoRoot(t)
+	reportXML := filepath.Join(filepath.Dir(root), "sumeru_addons", "account", "views", "report_actions.xml")
+	if _, err := os.Stat(reportXML); err != nil {
+		t.Skipf("account report_actions.xml not present at %s", reportXML)
+	}
+	raw, err := os.ReadFile(reportXML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var vl parser.ViewList
+	if err := xml.Unmarshal(raw, &vl); err != nil {
+		t.Fatal(err)
+	}
+	vl.MergeViewListData()
+	want := map[string]string{
+		"action_report_profit_loss":      "/account/reports/view?type=profit_loss",
+		"action_report_balance_sheet":    "/account/reports/view?type=balance_sheet",
+		"action_report_trial_balance":    "/account/reports/view?type=trial_balance",
+		"action_report_general_ledger":   "/account/reports/view?type=general_ledger",
+		"action_report_partner_ledger":   "/account/reports/view?type=partner_ledger",
+		"action_report_aged_receivable":  "/account/reports/view?type=aged_receivable",
+		"action_report_aged_payable":     "/account/reports/view?type=aged_payable",
+		"action_report_cash_flow":        "/account/reports/view?type=cash_flow",
+		"action_report_annual_composite": "/account/reports/view?type=annual_composite",
+	}
+	got := map[string]string{}
+	for _, rec := range vl.Records {
+		if rec.Model != "sys.action.url" {
+			t.Fatalf("record %s model=%q want sys.action.url", rec.ID, rec.Model)
+		}
+		var url string
+		for _, f := range rec.Field {
+			if f.Name == "url" {
+				url = f.Body
+			}
+		}
+		got[rec.ID] = url
+	}
+	for id, path := range want {
+		if got[id] != path {
+			t.Fatalf("%s url=%q want %q", id, got[id], path)
+		}
+	}
+}
+
+func TestAccountBankReconcileIsURLAction(t *testing.T) {
+	root := harness.RepoRoot(t)
+	bankXML := filepath.Join(filepath.Dir(root), "sumeru_addons", "account", "views", "account_bank_actions.xml")
+	if _, err := os.Stat(bankXML); err != nil {
+		t.Skipf("account bank actions not present at %s", bankXML)
+	}
+	raw, err := os.ReadFile(bankXML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var vl parser.ViewList
+	if err := xml.Unmarshal(raw, &vl); err != nil {
+		t.Fatal(err)
+	}
+	vl.MergeViewListData()
+	var found bool
+	for _, rec := range vl.Records {
+		if rec.ID != "action_bank_reconcile_workspace" {
+			continue
+		}
+		found = true
+		if rec.Model != "sys.action.url" {
+			t.Fatalf("model=%q want sys.action.url", rec.Model)
+		}
+		var url string
+		for _, f := range rec.Field {
+			if f.Name == "url" {
+				url = f.Body
+			}
+		}
+		if url != "/account/bank/reconcile" {
+			t.Fatalf("url=%q", url)
+		}
+	}
+	if !found {
+		t.Fatal("action_bank_reconcile_workspace not found")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `sys.action.url` end-to-end (ORM, XML parser, data sync, polymorphic `/web` resolution) so menu URL actions (e.g. account reports) no longer fall through to Apps.
- Embed URL actions in the workspace shell via SWC `IframeView` instead of a bare redirect.
- Unify falsy domain semantics (`= false` / `!= false`) across ORM field types, including Many2One NULL checks.

## Test plan
- [ ] `make test-modules-static`
- [ ] `go test ./test/core/orm/ ./test/core/server/web/ ./test/core/engine/parser/ -count=1`
- [ ] Upgrade/resync `account`, then open Invoicing → Reporting → Profit & Loss (loads in shell iframe)
- [ ] Confirm window actions (e.g. Invoice Analysis list) still open normally
- [ ] Spot-check domains that use `= false` / `!= false` on M2O and other field types