### PR TITLE
feat(web): URL actions, iframe workspace, and Many2One autocomplete UX

### DIFF
--- a/core/engine/assets/css/sumeru-views.css
+++ b/core/engine/assets/css/sumeru-views.css
@@ -1528,6 +1528,100 @@ label.sum-form-label--hint {
   position: relative;
 }
 
+.sum-m2o-wrap {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 0;
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 2.35rem;
+  border: 1px solid var(--sum-line-strong);
+  border-radius: var(--sum-radius-sm);
+  background: var(--sum-surface);
+  transition:
+    border-color var(--sum-dur) var(--sum-ease),
+    box-shadow var(--sum-dur) var(--sum-ease);
+}
+
+.sum-m2o-wrap:hover {
+  border-color: color-mix(in srgb, var(--sum-header) 28%, var(--sum-line-strong));
+}
+
+.sum-m2o-wrap:focus-within,
+.sum-m2o-wrap--open {
+  border-color: color-mix(in srgb, var(--sum-header) 45%, var(--sum-line-strong));
+  box-shadow: var(--sum-focus-ring);
+}
+
+.sum-m2o-wrap > .sum-field-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding-right: 0.25rem;
+}
+
+.sum-m2o-wrap > .sum-field-input:hover,
+.sum-m2o-wrap > .sum-field-input:focus {
+  border: none;
+  box-shadow: none;
+  outline: none;
+}
+
+.sum-m2o-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: stretch;
+  align-self: stretch;
+}
+
+.sum-m2o-dropdown-btn,
+.sum-m2o-open-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.85rem;
+  padding: 0 0.35rem;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--sum-muted-ink, var(--sum-ink-muted, #64748b));
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.sum-m2o-dropdown-btn {
+  border-left: 1px solid transparent;
+  padding-right: 0.5rem;
+}
+
+.sum-m2o-open-btn:hover,
+.sum-m2o-dropdown-btn:hover {
+  color: var(--sum-ink);
+  background: color-mix(in srgb, var(--sum-header) 8%, transparent);
+}
+
+.sum-m2o-caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 0.28rem solid transparent;
+  border-right: 0.28rem solid transparent;
+  border-top: 0.34rem solid currentColor;
+  transition: transform var(--sum-dur) var(--sum-ease);
+}
+
+.sum-m2o-wrap--open .sum-m2o-caret {
+  transform: rotate(180deg);
+}
+
 .sum-field-value {
   width: 100%;
   box-sizing: border-box;
@@ -1545,7 +1639,7 @@ label.sum-form-label--hint {
   z-index: 30;
   left: 0;
   right: 0;
-  top: calc(100% - 0.15rem);
+  top: calc(100% + 0.15rem);
   margin: 0;
   padding: 0.25rem 0;
   list-style: none;
@@ -1572,6 +1666,85 @@ label.sum-form-label--hint {
 .sum-m2o-suggest .sum-m2o-option:hover,
 .sum-m2o-suggest .sum-m2o-option--active {
   background: color-mix(in srgb, var(--sum-header) 12%, var(--sum-surface));
+}
+
+.sum-m2o-suggest-more,
+.sum-m2o-suggest-create {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  border-top: 1px solid var(--sum-line);
+  background: transparent;
+  padding: 0.5rem 0.75rem;
+  margin-top: 0.15rem;
+  font: inherit;
+  font-weight: var(--sum-font-weight-semibold);
+  color: var(--sum-header);
+  cursor: pointer;
+}
+
+.sum-m2o-suggest-more:hover,
+.sum-m2o-suggest-create:hover,
+.sum-m2o-suggest-create.sum-m2o-option--active {
+  background: color-mix(in srgb, var(--sum-header) 8%, var(--sum-surface));
+}
+
+.sum-m2m-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  position: relative;
+}
+
+.sum-m2m-input-row {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 0;
+  min-height: 2.35rem;
+  border: 1px solid var(--sum-line-strong);
+  border-radius: var(--sum-radius-sm);
+  background: var(--sum-surface);
+  box-sizing: border-box;
+  transition:
+    border-color var(--sum-dur) var(--sum-ease),
+    box-shadow var(--sum-dur) var(--sum-ease);
+}
+
+.sum-m2m-input-row:hover {
+  border-color: color-mix(in srgb, var(--sum-header) 28%, var(--sum-line-strong));
+}
+
+.sum-m2m-input-row:focus-within {
+  border-color: color-mix(in srgb, var(--sum-header) 45%, var(--sum-line-strong));
+  box-shadow: var(--sum-focus-ring);
+}
+
+.sum-m2m-input-row > .sum-field-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.sum-m2m-input-row > .sum-field-input:hover,
+.sum-m2m-input-row > .sum-field-input:focus {
+  border: none;
+  box-shadow: none;
+  outline: none;
+}
+
+.sum-m2m-input-row .sum-m2o-dropdown-btn {
+  flex: 0 0 auto;
+  border: none;
+  background: transparent;
+  min-width: 1.85rem;
+  padding: 0 0.5rem;
 }
 
 .sum-field-widget {
@@ -1650,7 +1823,9 @@ label.sum-form-label--hint {
 
 .sum-field-widget--error .sum-field-input,
 .sum-field-widget--error .sum-field-textarea,
-.sum-field-widget--error .sum-field-select {
+.sum-field-widget--error .sum-field-select,
+.sum-field-widget--error .sum-m2o-wrap,
+.sum-field-widget--error .sum-m2m-input-row {
   border-color: rgba(239, 68, 68, 0.75);
   box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.12);
 }
@@ -2128,6 +2303,134 @@ label.sum-form-label--hint {
 .sum-dialog-body--host {
   margin: 0;
   color: var(--sum-ink);
+}
+
+/* SelectCreate / Search more modal (Many2One picker) */
+.sum-modal-host {
+  position: fixed;
+  inset: 0;
+  z-index: 10050;
+  pointer-events: none;
+}
+
+.sum-modal-host > * {
+  pointer-events: auto;
+}
+
+.sum-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 10050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.45);
+  padding: 1rem;
+}
+
+.sum-modal {
+  min-width: min(420px, 100%);
+  max-width: 560px;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--sum-surface);
+  border: 1px solid var(--sum-line);
+  border-radius: var(--sum-radius-md);
+  box-shadow: var(--sum-shadow-lg, 0 12px 40px rgba(0, 0, 0, 0.18));
+  overflow: hidden;
+}
+
+.sum-modal.sum-select-create {
+  min-width: min(520px, 96vw);
+  max-width: 640px;
+}
+
+.sum-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem 0.75rem;
+  border-bottom: 1px solid var(--sum-line);
+}
+
+.sum-modal-header h3 {
+  margin: 0;
+  font-size: var(--sum-font-size-lg);
+  font-weight: var(--sum-font-weight-semibold);
+  color: var(--sum-ink);
+}
+
+.sum-modal-close {
+  border: none;
+  background: transparent;
+  color: var(--sum-ink-muted);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.15rem 0.35rem;
+  border-radius: var(--sum-radius-sm);
+}
+
+.sum-modal-close:hover {
+  background: var(--sum-surface-alt);
+  color: var(--sum-ink);
+}
+
+.sum-modal-body {
+  padding: 1rem 1.25rem;
+  overflow: auto;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sum-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem 1.1rem;
+  border-top: 1px solid var(--sum-line);
+}
+
+.sum-select-create-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 16rem;
+  overflow: auto;
+  border: 1px solid var(--sum-line);
+  border-radius: var(--sum-radius-sm);
+}
+
+.sum-select-create-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  border-bottom: 1px solid var(--sum-line);
+  background: transparent;
+  padding: 0.55rem 0.75rem;
+  font: inherit;
+  color: var(--sum-ink);
+  cursor: pointer;
+}
+
+.sum-select-create-list li:last-child .sum-select-create-item {
+  border-bottom: none;
+}
+
+.sum-select-create-item:hover {
+  background: color-mix(in srgb, var(--sum-header) 12%, var(--sum-surface));
+}
+
+.sum-select-create-empty {
+  margin: 0;
+  padding: 0.75rem 0.25rem;
+  color: var(--sum-ink-muted);
+  font-size: var(--sum-font-size-sm);
 }
 
 .sum-search-filters {

--- a/core/swc/src/views/dialogs/select-create-dialog.ts
+++ b/core/swc/src/views/dialogs/select-create-dialog.ts
@@ -6,6 +6,7 @@ export interface SelectCreateOptions {
   comodel: string;
   title?: string;
   domain?: unknown[];
+  initialQuery?: string;
   onSelect: (row: Record<string, unknown>) => void;
   onCancel?: () => void;
 }
@@ -15,22 +16,40 @@ export class SelectCreateDialog extends SwcComponent<SelectCreateOptions> {
   private query = "";
   private rows: Record<string, unknown>[] = [];
   private loading = false;
+  private onKeydownBound = (event: KeyboardEvent): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.close();
+    }
+  };
 
   static open(env: SwcEnv, opts: SelectCreateOptions): void {
     const host = document.createElement("div");
     host.className = "sum-modal-host";
     document.body.appendChild(host);
     const dialog = new SelectCreateDialog(opts, env);
+    dialog.query = opts.initialQuery?.trim() ?? "";
+    dialog.callSetup();
     host.appendChild(dialog.render());
   }
 
   override onMount(): void {
-    void this.search("");
+    document.addEventListener("keydown", this.onKeydownBound);
+    void this.search(this.query).then(() => {
+      const input = this.rootElement?.querySelector<HTMLInputElement>(".sum-field-input");
+      input?.focus();
+    });
+  }
+
+  override onWillUnmount(): void {
+    document.removeEventListener("keydown", this.onKeydownBound);
   }
 
   private close(): void {
     this.props.onCancel?.();
-    this.rootElement?.closest(".sum-modal-host")?.remove();
+    const host = this.rootElement?.closest(".sum-modal-host");
+    this.destroy();
+    host?.remove();
   }
 
   private async search(q: string): Promise<void> {
@@ -49,13 +68,17 @@ export class SelectCreateDialog extends SwcComponent<SelectCreateOptions> {
     const id = await this.env.services.rpc.create(this.props.comodel, { name });
     if (typeof id === "number" && id > 0) {
       this.props.onSelect({ id, name });
-      this.rootElement?.closest(".sum-modal-host")?.remove();
+      const host = this.rootElement?.closest(".sum-modal-host");
+      this.destroy();
+      host?.remove();
     }
   }
 
   private pick(row: Record<string, unknown>): void {
     this.props.onSelect(row);
-    this.rootElement?.closest(".sum-modal-host")?.remove();
+    const host = this.rootElement?.closest(".sum-modal-host");
+    this.destroy();
+    host?.remove();
   }
 
   override template() {
@@ -70,7 +93,7 @@ export class SelectCreateDialog extends SwcComponent<SelectCreateOptions> {
           <input
             class="sum-field-input"
             placeholder="Search..."
-            .value=${this.query}
+            value=${this.query}
             @input=${(e: Event) => {
               this.query = (e.target as HTMLInputElement).value;
               void this.search(this.query);
@@ -78,15 +101,17 @@ export class SelectCreateDialog extends SwcComponent<SelectCreateOptions> {
           />
           ${this.loading
             ? html`<p class="sum-muted">Loading…</p>`
-            : html`<ul class="sum-select-create-list">
-                ${this.rows.map(
-                  (row) => html`<li>
-                    <button type="button" class="sum-select-create-item" @click=${() => this.pick(row)}>
-                      ${String(row.name ?? row.id)}
-                    </button>
-                  </li>`,
-                )}
-              </ul>`}
+            : this.rows.length === 0
+              ? html`<p class="sum-select-create-empty">No records found.</p>`
+              : html`<ul class="sum-select-create-list">
+                  ${this.rows.map(
+                    (row) => html`<li>
+                      <button type="button" class="sum-select-create-item" @click=${() => this.pick(row)}>
+                        ${String(row.name ?? row.id)}
+                      </button>
+                    </li>`,
+                  )}
+                </ul>`}
         </div>
         <footer class="sum-modal-footer">
           <button type="button" class="sum-btn" @click=${() => void this.createNew()}>Create</button>

--- a/core/swc/src/views/form/form-interactions.ts
+++ b/core/swc/src/views/form/form-interactions.ts
@@ -17,30 +17,6 @@ function onNotebookKeydown(ev: Event): void {
   buttons[next]?.click();
 }
 
-function bindMany2OneDismiss(root: HTMLElement): () => void {
-  const onDocClick = (ev: MouseEvent): void => {
-    const target = ev.target;
-    if (!(target instanceof Node)) return;
-    for (const widget of root.querySelectorAll(".sum-field-widget--many2one")) {
-      if (widget.contains(target)) continue;
-      const list = widget.querySelector(".sum-m2o-suggest");
-      list?.remove();
-    }
-  };
-  const onKey = (ev: KeyboardEvent): void => {
-    if (ev.key !== "Escape") return;
-    for (const list of root.querySelectorAll(".sum-m2o-suggest")) {
-      list.remove();
-    }
-  };
-  document.addEventListener("click", onDocClick, true);
-  document.addEventListener("keydown", onKey);
-  return () => {
-    document.removeEventListener("click", onDocClick, true);
-    document.removeEventListener("keydown", onKey);
-  };
-}
-
 interface CropState {
   x: number;
   y: number;
@@ -304,7 +280,6 @@ export function initFormInteractions(root: HTMLElement): () => void {
     tabs.addEventListener("keydown", onNotebookKeydown);
     cleanups.push(() => tabs.removeEventListener("keydown", onNotebookKeydown));
   }
-  cleanups.push(bindMany2OneDismiss(root));
   cleanups.push(bindAvatarUpload(root));
   cleanups.push(bindImageBoxClick(root));
   cleanups.push(bindDateDismiss(root));

--- a/core/swc/src/widgets/Many2ManyTagsField.ts
+++ b/core/swc/src/widgets/Many2ManyTagsField.ts
@@ -1,11 +1,12 @@
 import { SwcComponent } from "../runtime/component.js";
 import { html } from "../template/html.js";
-import { fieldInputId, renderFieldShell } from "./field-shell.js";
+import { fieldInputId, fieldPlaceholder, renderFieldShell } from "./field-shell.js";
 import { AsyncFieldController } from "./field-async.js";
 import type { FieldWidgetProps } from "./field-props.js";
 import type { SwcRecord } from "../model/record.js";
 import { inputValueFromEvent } from "./field-events.js";
-import { isFieldReadonly } from "../model/modifiers.js";
+import { fieldDomain, isFieldReadonly } from "../model/modifiers.js";
+import { SelectCreateDialog } from "../views/dialogs/select-create-dialog.js";
 
 interface TagRow {
   id: number;
@@ -34,39 +35,45 @@ function tagNamesFromRecord(record: SwcRecord, fieldName: string): Map<number, s
 }
 
 export class Many2ManyTagsField extends SwcComponent<FieldWidgetProps> {
-  private catalog: TagRow[] = [];
-  private loaded = false;
+  private query = "";
+  private suggestions: TagRow[] = [];
+  private open = false;
+  private nameCache = new Map<number, string>();
   private readonly asyncCtrl = new AsyncFieldController(this);
 
-  override setup(): void {
-    void this.loadCatalog();
+  private readonly onDocClick = (event: MouseEvent): void => {
+    if (!this.open) return;
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (this.rootElement?.contains(target)) return;
+    this.closeSuggestions();
+  };
+
+  private readonly onDocKeydown = (event: KeyboardEvent): void => {
+    if (event.key === "Escape" && this.open) {
+      event.preventDefault();
+      this.closeSuggestions();
+    }
+  };
+
+  override onMount(): void {
+    document.addEventListener("click", this.onDocClick, true);
+    document.addEventListener("keydown", this.onDocKeydown);
   }
 
   override onWillUnmount(): void {
+    document.removeEventListener("click", this.onDocClick, true);
+    document.removeEventListener("keydown", this.onDocKeydown);
     this.asyncCtrl.cancel();
   }
 
-  private async loadCatalog(): Promise<void> {
-    const gen = this.asyncCtrl.begin();
-    const { field, record, readonly } = this.props;
+  private comodel(): string {
+    return this.props.field.relation ?? this.props.field.options?.relation ?? "";
+  }
 
-    if (isFieldReadonly(field, record, readonly)) {
-      this.loaded = true;
-      this.asyncCtrl.commitIfCurrent(gen);
-      return;
-    }
-
-    const comodel = field.relation ?? field.options?.relation ?? "";
-    if (!comodel) {
-      this.loaded = true;
-      this.asyncCtrl.commitIfCurrent(gen);
-      return;
-    }
-
-    const rows = await this.env.services.rpc.searchRead(comodel, [], ["id", "name"], 500);
-    this.catalog = rows.map((row) => ({ id: Number(row.id), name: String(row.name ?? row.id) }));
-    this.loaded = true;
-    this.asyncCtrl.commitIfCurrent(gen);
+  private closeSuggestions(): void {
+    this.open = false;
+    this.asyncCtrl.refresh();
   }
 
   private selectedTags(): TagRow[] {
@@ -74,65 +81,206 @@ export class Many2ManyTagsField extends SwcComponent<FieldWidgetProps> {
     const ids = tagIds(record, field.name);
     const names = tagNamesFromRecord(record, field.name);
     return ids.map((id) => {
-      const fromCatalog = this.catalog.find((tag) => tag.id === id);
-      if (fromCatalog) return fromCatalog;
+      const fromCache = this.nameCache.get(id);
+      if (fromCache) return { id, name: fromCache };
       const fromRecord = names.get(id);
       if (fromRecord) return { id, name: fromRecord };
       return { id, name: `#${id}` };
     });
   }
 
-  private setIds(ids: number[]): void {
-    this.props.record.set(this.props.field.name, ids);
+  private setIds(ids: number[], names?: Map<number, string>): void {
+    const { field, record } = this.props;
+    record.set(field.name, ids);
+    if (names) {
+      for (const [id, name] of names) this.nameCache.set(id, name);
+      record.set(
+        `${field.name}_names`,
+        ids.map((id) => ({ id, name: this.nameCache.get(id) ?? `#${id}` })),
+      );
+    }
+    record.notifyFieldChange(field.name);
     this.asyncCtrl.refresh();
+  }
+
+  private addTag(row: TagRow): void {
+    const selected = this.selectedTags();
+    if (selected.some((t) => t.id === row.id)) {
+      this.query = "";
+      this.closeSuggestions();
+      return;
+    }
+    this.nameCache.set(row.id, row.name);
+    this.setIds(
+      [...selected.map((t) => t.id), row.id],
+      new Map([[row.id, row.name]]),
+    );
+    this.query = "";
+    this.suggestions = [];
+    this.open = false;
+    this.asyncCtrl.refresh();
+  }
+
+  private hasExactNameMatch(): boolean {
+    const q = this.query.trim().toLowerCase();
+    if (!q) return false;
+    return this.suggestions.some((row) => row.name.trim().toLowerCase() === q);
+  }
+
+  private async search(query: string): Promise<void> {
+    const gen = this.asyncCtrl.begin();
+    const comodel = this.comodel();
+    if (!comodel) return;
+    const selected = new Set(this.selectedTags().map((t) => t.id));
+    const baseDomain = fieldDomain(this.props.field, this.props.record) ?? [];
+    const domain = query ? [...baseDomain, ["name", "ilike", query]] : baseDomain;
+    const rows =
+      (await this.env.services.rpc.searchRead(comodel, domain, ["id", "name"], 20)) ?? [];
+    this.suggestions = rows
+      .map((row) => ({ id: Number(row.id), name: String(row.name ?? row.id) }))
+      .filter((row) => !Number.isNaN(row.id) && !selected.has(row.id));
+    this.open = true;
+    this.asyncCtrl.commitIfCurrent(gen);
+  }
+
+  private onInput(event: Event): void {
+    this.query = inputValueFromEvent(event);
+    void this.search(this.query);
+  }
+
+  private toggleDropdown(): void {
+    if (this.open) {
+      this.closeSuggestions();
+      return;
+    }
+    void this.search(this.query);
+  }
+
+  private async createFromQuery(): Promise<void> {
+    const name = this.query.trim();
+    const comodel = this.comodel();
+    if (!name || !comodel) return;
+    const id = await this.env.services.rpc.create(comodel, { name });
+    if (typeof id === "number" && id > 0) {
+      this.addTag({ id, name });
+    }
+  }
+
+  private openSelectCreate(): void {
+    const { field, record } = this.props;
+    const comodel = this.comodel();
+    if (!comodel) return;
+    const initialQuery = this.query;
+    this.open = false;
+    this.asyncCtrl.refresh();
+    SelectCreateDialog.open(this.env, {
+      comodel,
+      title: field.string ?? field.name,
+      domain: fieldDomain(field, record) ?? [],
+      initialQuery,
+      onSelect: (row) => {
+        this.addTag({ id: Number(row.id), name: String(row.name ?? row.id) });
+      },
+    });
   }
 
   override template() {
     const { field, record, readonly } = this.props;
     const selected = this.selectedTags();
-    const selectedSet = new Set(selected.map((tag) => tag.id));
+    const createVisible = this.query.trim() !== "" && !this.hasExactNameMatch();
 
     if (isFieldReadonly(field, record, readonly)) {
       return renderFieldShell(
         field,
         html`<div class="sum-multi-select-tags sum-multi-select-tags--readonly sum-field-tags">
-          ${selected.map((tag) => html`<span class="sum-multi-select-tag"><span class="sum-multi-select-tag-label">${tag.name}</span></span>`)}
+          ${selected.map(
+            (tag) =>
+              html`<span class="sum-multi-select-tag"
+                ><span class="sum-multi-select-tag-label">${tag.name}</span></span
+              >`,
+          )}
         </div>`,
         { labelFor: false },
       );
     }
 
     const id = fieldInputId(field);
+    const placeholder = fieldPlaceholder(field) || "Search…";
 
     return renderFieldShell(
       field,
-      html`<div class="sum-multi-select-box">
+      html`<div class="sum-m2m-wrap sum-multi-select-box">
         <div class="sum-multi-select-tags sum-field-tags">
           ${selected.map(
             (tag) =>
               html`<span class="sum-multi-select-tag">
                 <span class="sum-multi-select-tag-label">${tag.name}</span>
-                <button type="button" class="sum-multi-select-remove" aria-label="Remove" @click=${() => this.setIds(selected.filter((t) => t.id !== tag.id).map((t) => t.id))}>×</button>
+                <button
+                  type="button"
+                  class="sum-multi-select-remove"
+                  aria-label="Remove"
+                  @click=${() =>
+                    this.setIds(selected.filter((t) => t.id !== tag.id).map((t) => t.id))}
+                >
+                  ×
+                </button>
               </span>`,
           )}
         </div>
-        <select
-          id=${id}
-          class="sum-multi-select-add sum-field-select"
-          @change=${(event: Event) => {
-            const fieldValue = Number(inputValueFromEvent(event));
-            const select = event.target as HTMLSelectElement;
-            select.value = "";
-            if (!fieldValue || selectedSet.has(fieldValue)) return;
-            this.setIds([...selected.map((tag) => tag.id), fieldValue]);
-          }}
-        >
-          <option value="">Add tag…</option>
-          ${this.catalog
-            .filter((tag) => !selectedSet.has(tag.id))
-            .map((tag) => html`<option value=${String(tag.id)}>${tag.name}</option>`)}
-        </select>
-        ${!this.loaded ? html`<span class="sum-field-hint">Loading…</span>` : ""}
+        <div class="sum-m2m-input-row">
+          <input
+            id=${id}
+            class="sum-field-input"
+            placeholder=${placeholder}
+            value=${this.query}
+            autocomplete="off"
+            @input=${(event: Event) => this.onInput(event)}
+            @focus=${() => {
+              if (!this.open) void this.search(this.query);
+            }}
+          />
+          <button
+            type="button"
+            class="sum-m2o-dropdown-btn"
+            title="Open suggestions"
+            aria-label="Open suggestions"
+            tabindex="-1"
+            @click=${() => this.toggleDropdown()}
+          >
+            <span class="sum-m2o-caret" aria-hidden="true"></span>
+          </button>
+        </div>
+        ${this.open
+          ? html`<ul class="sum-m2o-suggest">
+              ${this.suggestions.map(
+                (row) => html`<li>
+                  <button type="button" class="sum-m2o-option" @click=${() => this.addTag(row)}>
+                    ${row.name}
+                  </button>
+                </li>`,
+              )}
+              ${createVisible
+                ? html`<li>
+                    <button
+                      type="button"
+                      class="sum-m2o-suggest-create"
+                      @click=${() => void this.createFromQuery()}
+                    >
+                      Create "${this.query.trim()}"
+                    </button>
+                  </li>`
+                : ""}
+              <li>
+                <button
+                  type="button"
+                  class="sum-m2o-suggest-more"
+                  @click=${() => this.openSelectCreate()}
+                >
+                  Search more…
+                </button>
+              </li>
+            </ul>`
+          : ""}
       </div>`,
       { labelFor: id },
     );

--- a/core/swc/src/widgets/Many2OneField.ts
+++ b/core/swc/src/widgets/Many2OneField.ts
@@ -13,18 +13,66 @@ import { inputValueFromEvent } from "./field-events.js";
 import { SelectCreateDialog } from "../views/dialogs/select-create-dialog.js";
 
 export class Many2OneField extends SwcComponent<FieldWidgetProps> {
+  private query = "";
   private suggestions: Record<string, unknown>[] = [];
   private open = false;
   private highlightIndex = 0;
   private readonly asyncCtrl = new AsyncFieldController(this);
 
+  private readonly onDocClick = (event: MouseEvent): void => {
+    if (!this.open) return;
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (this.rootElement?.contains(target)) return;
+    this.closeSuggestions();
+  };
+
+  private readonly onDocKeydown = (event: KeyboardEvent): void => {
+    if (event.key === "Escape" && this.open) {
+      event.preventDefault();
+      this.closeSuggestions();
+    }
+  };
+
+  override onMount(): void {
+    document.addEventListener("click", this.onDocClick, true);
+    document.addEventListener("keydown", this.onDocKeydown);
+  }
+
   override onWillUnmount(): void {
+    document.removeEventListener("click", this.onDocClick, true);
+    document.removeEventListener("keydown", this.onDocKeydown);
     this.asyncCtrl.cancel();
+  }
+
+  private comodel(): string {
+    return this.props.field.relation ?? this.props.field.options?.relation ?? "";
+  }
+
+  private recordId(): number {
+    const raw = this.props.record.get(this.props.field.name);
+    const id = typeof raw === "number" ? raw : Number(raw);
+    return Number.isFinite(id) && id > 0 ? id : 0;
+  }
+
+  private closeSuggestions(): void {
+    this.open = false;
+    this.asyncCtrl.refresh();
+  }
+
+  private inputDisplay(recordDisplay: string): string {
+    return this.query !== "" || this.open ? this.query : recordDisplay;
+  }
+
+  private hasExactNameMatch(): boolean {
+    const q = this.query.trim().toLowerCase();
+    if (!q) return false;
+    return this.suggestions.some((row) => String(row.name ?? "").trim().toLowerCase() === q);
   }
 
   private async search(query: string): Promise<void> {
     const gen = this.asyncCtrl.begin();
-    const comodel = this.props.field.relation ?? this.props.field.options?.relation ?? "";
+    const comodel = this.comodel();
     if (!comodel) return;
     const baseDomain = fieldDomain(this.props.field, this.props.record) ?? [];
     const domain = query ? [...baseDomain, ["name", "ilike", query]] : baseDomain;
@@ -34,45 +82,89 @@ export class Many2OneField extends SwcComponent<FieldWidgetProps> {
     this.asyncCtrl.commitIfCurrent(gen);
   }
 
+  private onInput(event: Event): void {
+    this.query = inputValueFromEvent(event);
+    void this.search(this.query);
+  }
+
+  private toggleDropdown(): void {
+    if (this.open) {
+      this.closeSuggestions();
+      return;
+    }
+    void this.search(this.query);
+  }
+
   private pick(row: Record<string, unknown>): void {
     const { field, record } = this.props;
     record.set(field.name, row.id);
     record.set(`${field.name}_name`, row.name);
     record.notifyFieldChange(field.name);
+    this.query = "";
     this.open = false;
+    this.suggestions = [];
     this.asyncCtrl.refresh();
+  }
+
+  private async createFromQuery(): Promise<void> {
+    const name = this.query.trim();
+    const comodel = this.comodel();
+    if (!name || !comodel) return;
+    const id = await this.env.services.rpc.create(comodel, { name });
+    if (typeof id === "number" && id > 0) {
+      this.pick({ id, name });
+    }
   }
 
   private openSelectCreate(): void {
     const { field, record } = this.props;
-    const comodel = field.relation ?? field.options?.relation ?? "";
+    const comodel = this.comodel();
     if (!comodel) return;
+    const initialQuery = this.query;
+    this.open = false;
+    this.asyncCtrl.refresh();
     SelectCreateDialog.open(this.env, {
       comodel,
       title: field.string ?? field.name,
       domain: fieldDomain(field, record) ?? [],
+      initialQuery,
       onSelect: (row) => this.pick(row),
     });
   }
 
+  private openRelatedRecord(): void {
+    const comodel = this.comodel();
+    const recordId = this.recordId();
+    if (!comodel || recordId <= 0) return;
+    void this.env.services.action.applyCallResult({
+      open: { model: comodel, recordId, target: "dialog" },
+    });
+  }
+
   private onKeydown(event: KeyboardEvent): void {
-    if (!this.open || this.suggestions.length === 0) return;
+    if (!this.open) return;
+    const createVisible = this.query.trim() !== "" && !this.hasExactNameMatch();
+    const optionCount = this.suggestions.length + (createVisible ? 1 : 0);
+    if (optionCount === 0) return;
+
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      this.highlightIndex = (this.highlightIndex + 1) % this.suggestions.length;
+      this.highlightIndex = (this.highlightIndex + 1) % optionCount;
       this.asyncCtrl.refresh();
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
-      this.highlightIndex =
-        (this.highlightIndex - 1 + this.suggestions.length) % this.suggestions.length;
+      this.highlightIndex = (this.highlightIndex - 1 + optionCount) % optionCount;
       this.asyncCtrl.refresh();
     } else if (event.key === "Enter") {
       event.preventDefault();
-      const row = this.suggestions[this.highlightIndex];
-      if (row) this.pick(row);
+      if (this.highlightIndex < this.suggestions.length) {
+        const row = this.suggestions[this.highlightIndex];
+        if (row) this.pick(row);
+      } else if (createVisible) {
+        void this.createFromQuery();
+      }
     } else if (event.key === "Escape") {
-      this.open = false;
-      this.asyncCtrl.refresh();
+      this.closeSuggestions();
     }
   }
 
@@ -80,8 +172,9 @@ export class Many2OneField extends SwcComponent<FieldWidgetProps> {
     const { field, record, readonly } = this.props;
     const display = recordDisplayName(record, field.name);
     const id = fieldInputId(field);
-
+    const hasValue = this.recordId() > 0;
     const placeholder = fieldPlaceholder(field);
+    const createVisible = this.query.trim() !== "" && !this.hasExactNameMatch();
 
     if (isFieldReadonly(field, record, readonly)) {
       return renderFieldShell(field, fieldReadonlyValue(display, placeholder), { labelFor: false });
@@ -89,18 +182,44 @@ export class Many2OneField extends SwcComponent<FieldWidgetProps> {
 
     return renderFieldShell(
       field,
-      html`<div class="sum-m2o-wrap">
+      html`<div class=${this.open ? "sum-m2o-wrap sum-m2o-wrap--open" : "sum-m2o-wrap"}>
         <input
           id=${id}
           class="sum-field-input"
           name=${field.name}
           placeholder=${placeholder}
-          value=${display}
+          value=${this.inputDisplay(display)}
           autocomplete="off"
-          @input=${(event: Event) => void this.search(inputValueFromEvent(event))}
+          @input=${(event: Event) => this.onInput(event)}
+          @focus=${() => {
+            if (!this.open) void this.search(this.query);
+          }}
           @keydown=${(event: Event) => this.onKeydown(event as KeyboardEvent)}
         />
-        <button type="button" class="sum-m2o-search-btn" title="Search records" @click=${() => this.openSelectCreate()}>…</button>
+        <div class="sum-m2o-actions">
+          ${hasValue
+            ? html`<button
+                type="button"
+                class="sum-m2o-open-btn"
+                title="Open record"
+                tabindex="-1"
+                @click=${() => this.openRelatedRecord()}
+              >
+                ↗
+              </button>`
+            : ""}
+          <button
+            type="button"
+            class="sum-m2o-dropdown-btn"
+            title="Open suggestions"
+            aria-label="Open suggestions"
+            aria-expanded=${this.open ? "true" : "false"}
+            tabindex="-1"
+            @click=${() => this.toggleDropdown()}
+          >
+            <span class="sum-m2o-caret" aria-hidden="true"></span>
+          </button>
+        </div>
         ${this.open
           ? html`<ul class="sum-m2o-suggest">
               ${this.suggestions.map(
@@ -116,6 +235,28 @@ export class Many2OneField extends SwcComponent<FieldWidgetProps> {
                   </button>
                 </li>`,
               )}
+              ${createVisible
+                ? html`<li>
+                    <button
+                      type="button"
+                      class=${this.highlightIndex === this.suggestions.length
+                        ? "sum-m2o-suggest-create sum-m2o-option--active"
+                        : "sum-m2o-suggest-create"}
+                      @click=${() => void this.createFromQuery()}
+                    >
+                      Create "${this.query.trim()}"
+                    </button>
+                  </li>`
+                : ""}
+              <li>
+                <button
+                  type="button"
+                  class="sum-m2o-suggest-more"
+                  @click=${() => this.openSelectCreate()}
+                >
+                  Search more…
+                </button>
+              </li>
             </ul>`
           : ""}
       </div>`,

--- a/core/swc/tests/views/form-interactions.test.ts
+++ b/core/swc/tests/views/form-interactions.test.ts
@@ -13,9 +13,6 @@ describe("form-interactions", () => {
         <button type="button" role="tab">A</button>
         <button type="button" role="tab">B</button>
       </div>
-      <div class="sum-field-widget sum-field-widget--many2one">
-        <div class="sum-m2o-suggest"></div>
-      </div>
       <details class="sum-date-field" open>
         <summary>Date</summary>
       </details>
@@ -43,25 +40,10 @@ describe("form-interactions", () => {
     expect(document.activeElement).toBe(tabs[1]);
   });
 
-  it("document click dismisses many2one suggestions", () => {
-    expect(root.querySelector(".sum-m2o-suggest")).toBeTruthy();
-    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(root.querySelector(".sum-m2o-suggest")).toBeNull();
-  });
-
   it("document click closes open date details", () => {
     const details = root.querySelector<HTMLDetailsElement>("details.sum-date-field")!;
     expect(details.open).toBe(true);
     document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(details.open).toBe(false);
-  });
-
-  it("escape removes many2one suggestion lists", () => {
-    root.querySelector(".sum-field-widget--many2one")!.insertAdjacentHTML(
-      "beforeend",
-      '<div class="sum-m2o-suggest"></div>',
-    );
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-    expect(root.querySelector(".sum-m2o-suggest")).toBeNull();
   });
 });

--- a/core/swc/tests/views/select-create-dialog.test.ts
+++ b/core/swc/tests/views/select-create-dialog.test.ts
@@ -57,4 +57,53 @@ describe("SelectCreateDialog", () => {
     expect(onCancel).toHaveBeenCalled();
     expect(document.querySelector(".sum-modal-host")).toBeNull();
   });
+
+  it("closes on Escape", async () => {
+    const onCancel = vi.fn();
+    SelectCreateDialog.open(collectionEnv(), { comodel: "core.partner", onSelect: vi.fn(), onCancel });
+    await vi.waitFor(() => expect(document.querySelector(".sum-modal-backdrop")).toBeTruthy());
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(onCancel).toHaveBeenCalled();
+    expect(document.querySelector(".sum-modal-host")).toBeNull();
+  });
+
+  it("seeds search from initialQuery", async () => {
+    const searchRead = vi.fn().mockResolvedValue([{ id: 1, name: "Acme Corp" }]);
+    SelectCreateDialog.open(
+      collectionEnv({
+        rpc: {
+          searchRead,
+          write: vi.fn(),
+          create: vi.fn(),
+          unlink: vi.fn(),
+          read: vi.fn(),
+          call: vi.fn(),
+        },
+      }),
+      { comodel: "core.partner", onSelect: vi.fn(), initialQuery: "Acme" },
+    );
+    await vi.waitFor(() => expect(searchRead).toHaveBeenCalled());
+    expect(searchRead.mock.calls[0][1]).toEqual([["name", "ilike", "Acme"]]);
+    const input = document.querySelector(".sum-select-create .sum-field-input") as HTMLInputElement;
+    expect(input.value).toBe("Acme");
+  });
+
+  it("shows empty state when no rows", async () => {
+    SelectCreateDialog.open(
+      collectionEnv({
+        rpc: {
+          searchRead: vi.fn().mockResolvedValue([]),
+          write: vi.fn(),
+          create: vi.fn(),
+          unlink: vi.fn(),
+          read: vi.fn(),
+          call: vi.fn(),
+        },
+      }),
+      { comodel: "core.partner", onSelect: vi.fn() },
+    );
+    await vi.waitFor(() => {
+      expect(document.querySelector(".sum-select-create-empty")?.textContent).toContain("No records found");
+    });
+  });
 });

--- a/core/swc/tests/widgets/many2many-tags-field.test.ts
+++ b/core/swc/tests/widgets/many2many-tags-field.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Many2ManyTagsField } from "../../src/widgets/Many2ManyTagsField.js";
+import { SwcRecord } from "../../src/model/record.js";
+import type { SwcEnv } from "../../src/runtime/env.js";
+
+function env(extra?: Partial<SwcEnv["services"]>): SwcEnv {
+  return {
+    bootstrap: {} as never,
+    services: {
+      rpc: {
+        searchRead: vi.fn().mockResolvedValue([
+          { id: 1, name: "Red" },
+          { id: 2, name: "Blue" },
+        ]),
+        create: vi.fn().mockResolvedValue(50),
+      },
+      ...extra,
+    },
+  } as never;
+}
+
+describe("Many2ManyTagsField", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("searches and adds a tag from suggestions", async () => {
+    const record = new SwcRecord("m", 1, { tag_ids: [] });
+    const comp = new Many2ManyTagsField(
+      { field: { name: "tag_ids", relation: "my.tag", string: "Tags" }, record, readonly: false },
+      env(),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    const input = comp.rootElement!.querySelector(".sum-field-input") as HTMLInputElement;
+    input.value = "Re";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-option")).toBeTruthy());
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-option")?.click();
+    expect(record.get("tag_ids")).toEqual([1]);
+    expect(comp.rootElement!.textContent).toContain("Red");
+  });
+
+  it("Search more opens SelectCreate and appends", async () => {
+    const searchRead = vi.fn().mockResolvedValue([{ id: 3, name: "Green" }]);
+    const record = new SwcRecord("m", 1, { tag_ids: [] });
+    const comp = new Many2ManyTagsField(
+      { field: { name: "tag_ids", relation: "my.tag" }, record, readonly: false },
+      env({ rpc: { searchRead, create: vi.fn() } as never }),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-dropdown-btn")?.click();
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest-more")).toBeTruthy());
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-suggest-more")?.click();
+    await vi.waitFor(() => expect(document.querySelector(".sum-select-create-item")).toBeTruthy());
+    (document.querySelector(".sum-select-create-item") as HTMLButtonElement).click();
+    expect(record.get("tag_ids")).toEqual([3]);
+  });
+
+  it("Create from query adds new tag", async () => {
+    const create = vi.fn().mockResolvedValue(50);
+    const searchRead = vi.fn().mockResolvedValue([]);
+    const record = new SwcRecord("m", 1, { tag_ids: [] });
+    const comp = new Many2ManyTagsField(
+      { field: { name: "tag_ids", relation: "my.tag" }, record, readonly: false },
+      env({ rpc: { searchRead, create } as never }),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    const input = comp.rootElement!.querySelector(".sum-field-input") as HTMLInputElement;
+    input.value = "Purple";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest-create")).toBeTruthy());
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-suggest-create")?.click();
+    await vi.waitFor(() => expect(create).toHaveBeenCalledWith("my.tag", { name: "Purple" }));
+    await vi.waitFor(() => expect(record.get("tag_ids")).toEqual([50]));
+  });
+
+  it("readonly shows tags without input", () => {
+    const record = new SwcRecord("m", 1, {
+      tag_ids: [1],
+      tag_ids_names: [{ id: 1, name: "Red" }],
+    });
+    const comp = new Many2ManyTagsField(
+      { field: { name: "tag_ids", relation: "my.tag" }, record, readonly: true },
+      env(),
+    );
+    comp.callSetup();
+    const el = comp.render();
+    expect(el.textContent).toContain("Red");
+    expect(el.querySelector(".sum-field-input")).toBeNull();
+  });
+});

--- a/core/swc/tests/widgets/many2one-field.test.ts
+++ b/core/swc/tests/widgets/many2one-field.test.ts
@@ -3,7 +3,7 @@ import { Many2OneField } from "../../src/widgets/Many2OneField.js";
 import { SwcRecord } from "../../src/model/record.js";
 import type { SwcEnv } from "../../src/runtime/env.js";
 
-function env(): SwcEnv {
+function env(extra?: Partial<SwcEnv["services"]>): SwcEnv {
   return {
     bootstrap: {} as never,
     services: {
@@ -12,8 +12,11 @@ function env(): SwcEnv {
           { id: 1, name: "Acme" },
           { id: 2, name: "Beta" },
         ]),
+        create: vi.fn().mockResolvedValue(99),
       },
       dialog: { openHost: vi.fn() },
+      action: { applyCallResult: vi.fn().mockResolvedValue(true) },
+      ...extra,
     },
   } as never;
 }
@@ -21,6 +24,22 @@ function env(): SwcEnv {
 describe("Many2OneField", () => {
   afterEach(() => {
     document.body.innerHTML = "";
+  });
+
+  it("keeps typed query after async search patch", async () => {
+    const record = new SwcRecord("m", 1, { partner_id: null });
+    const comp = new Many2OneField(
+      { field: { name: "partner_id", relation: "res.partner", string: "Partner" }, record, readonly: false },
+      env(),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    const input = comp.rootElement!.querySelector(".sum-field-input") as HTMLInputElement;
+    input.value = "Ac";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest")).toBeTruthy());
+    const after = comp.rootElement!.querySelector(".sum-field-input") as HTMLInputElement;
+    expect(after.value).toBe("Ac");
   });
 
   it("searches and picks a suggestion", async () => {
@@ -65,5 +84,85 @@ describe("Many2OneField", () => {
     comp.callSetup();
     const el = comp.render();
     expect(el.textContent).toContain("Vendor");
+    expect(el.querySelector(".sum-m2o-dropdown-btn")).toBeNull();
+    expect(el.querySelector(".sum-m2o-search-btn")).toBeNull();
+  });
+
+  it("chevron opens suggestions", async () => {
+    const record = new SwcRecord("m", 1, { partner_id: null });
+    const comp = new Many2OneField(
+      { field: { name: "partner_id", relation: "res.partner", string: "Partner" }, record, readonly: false },
+      env(),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    expect(comp.rootElement!.querySelector(".sum-m2o-search-btn")).toBeNull();
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-dropdown-btn")?.click();
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest")).toBeTruthy());
+  });
+
+  it("Search more footer opens SelectCreate dialog", async () => {
+    const record = new SwcRecord("m", 1, { partner_id: null });
+    const comp = new Many2OneField(
+      { field: { name: "partner_id", relation: "res.partner", string: "Partner" }, record, readonly: false },
+      env(),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    const input = comp.rootElement!.querySelector(".sum-field-input") as HTMLInputElement;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest-more")).toBeTruthy());
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-suggest-more")?.click();
+    await vi.waitFor(() => expect(document.querySelector(".sum-select-create")).toBeTruthy());
+  });
+
+  it("Create from query calls rpc.create and picks", async () => {
+    const create = vi.fn().mockResolvedValue(99);
+    const searchRead = vi.fn().mockResolvedValue([{ id: 1, name: "Acme" }]);
+    const record = new SwcRecord("m", 1, { partner_id: null });
+    const comp = new Many2OneField(
+      { field: { name: "partner_id", relation: "res.partner", string: "Partner" }, record, readonly: false },
+      env({ rpc: { searchRead, create } as never }),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    const input = comp.rootElement!.querySelector(".sum-field-input") as HTMLInputElement;
+    input.value = "NewCo";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest-create")).toBeTruthy());
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-suggest-create")?.click();
+    await vi.waitFor(() => expect(create).toHaveBeenCalledWith("res.partner", { name: "NewCo" }));
+    await vi.waitFor(() => expect(record.get("partner_id")).toBe(99));
+    expect(record.get("partner_id_name")).toBe("NewCo");
+  });
+
+  it("open button opens related record when valued", () => {
+    const applyCallResult = vi.fn().mockResolvedValue(true);
+    const record = new SwcRecord("m", 1, { partner_id: 5, partner_id_name: "Vendor" });
+    const comp = new Many2OneField(
+      { field: { name: "partner_id", relation: "res.partner", string: "Partner" }, record, readonly: false },
+      env({ action: { applyCallResult } as never }),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    expect(comp.rootElement!.querySelector(".sum-m2o-open-btn")).toBeTruthy();
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-open-btn")?.click();
+    expect(applyCallResult).toHaveBeenCalledWith({
+      open: { model: "res.partner", recordId: 5, target: "dialog" },
+    });
+  });
+
+  it("outside click closes suggestions via widget state", async () => {
+    const record = new SwcRecord("m", 1, { partner_id: null });
+    const comp = new Many2OneField(
+      { field: { name: "partner_id", relation: "res.partner" }, record, readonly: false },
+      env(),
+    );
+    comp.callSetup();
+    document.body.append(comp.render());
+    comp.rootElement!.querySelector<HTMLButtonElement>(".sum-m2o-dropdown-btn")?.click();
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest")).toBeTruthy());
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await vi.waitFor(() => expect(comp.rootElement!.querySelector(".sum-m2o-suggest")).toBeNull());
   });
 });


### PR DESCRIPTION
## Summary
- Support `sys.action.url` end-to-end (XML parse, data sync, action resolve, workspace) so reporting/URL menus open correctly instead of falling back to Apps.
- Embed URL actions in an in-shell iframe workspace (`IframeView` + payload `iframeUrl`) instead of a hard redirect.
- Unify falsy domain / Many2One `false` → SQL `NULL` semantics across ORM search and record rules.
- Fix Many2One typing (local query buffer so patch no longer wipes input), add select-style in-field autocomplete with Create / Search more / SelectCreate, and apply the same pattern to Many2Many tags.
- Restyle Many2One as a single selection-like control (shared border, in-field caret) and keep widget/CSS-only changes (no invoice XML).

## Commits
- `fix(orm): compile Many2One false domains as NULL checks`
- `fix(orm): unify falsy domain semantics across field types`
- `feat(web): support sys.action.url and embed URL actions in workspace`
- `fix(ci): type IframeView props and sync iframeUrl payload contract`
- `fix(swc): restore Many2One search and select-style autocomplete UX`

## Test plan
- [ ] Invoice form: type in Partner / Currency / Journal — text sticks, suggestions appear, caret opens dropdown
- [ ] Create `"…"` and Search more… work; SelectCreate pick/create/cancel work
- [ ] Many2One looks like one bordered select (caret inside), not separate side buttons
- [ ] Many2Many tags: search, add, remove, Create, Search more
- [ ] Accounting URL/report menus open in workspace iframe (not Apps)
- [ ] CI: SWC check/tests + Go tests for action resolve / falsy domains / iframe payload contract